### PR TITLE
Remove PrimeSubField from traits

### DIFF
--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -18,7 +18,7 @@ where
 {
     /// The domain defined over the base field, used for initial FFT operations.
     ///
-    /// This is useful when operating in an extension field `F`, where `F::PrimeSubfield`
+    /// This is useful when operating in an extension field `EF`, where `F`
     /// represents the base field from which the extension was built.
     pub base_domain: Option<GeneralEvaluationDomain<F>>,
     /// The actual working domain used for FFT operations.
@@ -28,7 +28,7 @@ where
 impl<EF, F> Domain<EF, F>
 where
     F: Field + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
 {
     /// Constructs a new evaluation domain for a polynomial of given `degree`.
     ///
@@ -84,17 +84,17 @@ where
 
     /// Converts a base field evaluation domain into an extended field domain.
     ///
-    /// Maps elements from `F::PrimeSubfield` to `F`, preserving the subgroup structure.
+    /// Maps elements from `F` to `EF`, preserving the subgroup structure.
     fn to_extension_domain(domain: &GeneralEvaluationDomain<F>) -> GeneralEvaluationDomain<EF> {
-        let group_gen = EF::from_prime_subfield(domain.group_gen());
-        let group_gen_inv = EF::from_prime_subfield(domain.group_gen_inv());
+        let group_gen = EF::from(domain.group_gen());
+        let group_gen_inv = EF::from(domain.group_gen_inv());
         let size = domain.size() as u64;
         let log_size_of_group = domain.log_size_of_group();
-        let size_as_field_element = EF::from_prime_subfield(domain.size_as_field_element());
-        let size_inv = EF::from_prime_subfield(domain.size_inv());
-        let offset = EF::from_prime_subfield(domain.coset_offset());
-        let offset_inv = EF::from_prime_subfield(domain.coset_offset_inv());
-        let offset_pow_size = EF::from_prime_subfield(domain.coset_offset_pow_size());
+        let size_as_field_element = EF::from(domain.size_as_field_element());
+        let size_inv = EF::from(domain.size_inv());
+        let offset = EF::from(domain.coset_offset());
+        let offset_inv = EF::from(domain.coset_offset_inv());
+        let offset_pow_size = EF::from(domain.coset_offset_pow_size());
         match domain {
             GeneralEvaluationDomain::Radix2(_) => {
                 GeneralEvaluationDomain::Radix2(Radix2EvaluationDomain {

--- a/src/fiat_shamir/domain_separator.rs
+++ b/src/fiat_shamir/domain_separator.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, fmt::Write, marker::PhantomData};
 
-use p3_field::{BasedVectorSpace, ExtensionField, Field, PrimeField64, TwoAdicField};
+use p3_field::{ExtensionField, Field, PrimeField64, TwoAdicField};
 
 use super::{
     DefaultHash,
@@ -76,7 +76,7 @@ where
 impl<EF, F, H> DomainSeparator<EF, F, H>
 where
     H: DuplexSpongeInterface<u8>,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
     F: Field + TwoAdicField + PrimeField64,
 {
     pub const fn from_string(io: String) -> Self {
@@ -333,13 +333,7 @@ where
         // - `count` is the number of scalar values
         // - `extension_degree` is the number of limbs (e.g., 4 for quartic extensions)
         // - `bytes_modp(bits)` gives the compressed byte length for the prime subfield
-        self.absorb(
-            count
-                * EF::DIMENSION
-                * EF::PrimeSubfield::DIMENSION
-                * bytes_modp(EF::PrimeSubfield::bits() as u32),
-            label,
-        );
+        self.absorb(count * EF::DIMENSION * bytes_modp(F::bits() as u32), label);
     }
 
     pub fn challenge_scalars(&mut self, count: usize, label: &str) {
@@ -352,10 +346,7 @@ where
         // where `bytes_uniform_modp` gives the number of bytes needed to sample uniformly
         // over the base field.
         self.squeeze(
-            count
-                * EF::DIMENSION
-                * EF::PrimeSubfield::DIMENSION
-                * bytes_uniform_modp(EF::PrimeSubfield::bits() as u32),
+            count * EF::DIMENSION * bytes_uniform_modp(F::bits() as u32),
             label,
         );
     }

--- a/src/fiat_shamir/sho.rs
+++ b/src/fiat_shamir/sho.rs
@@ -28,7 +28,7 @@ impl<H: DuplexSpongeInterface<u8>> HashStateWithInstructions<H> {
     /// setting up the state of the sponge function and parsing the tag string.
     pub fn new<EF, F>(domain_separator: &DomainSeparator<EF, F, H>) -> Self
     where
-        EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+        EF: ExtensionField<F> + TwoAdicField,
         F: Field + TwoAdicField + PrimeField64,
     {
         let stack = domain_separator.finalize();

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -103,7 +103,7 @@ impl FoldType {
         stir_evaluations: &mut Vec<EF>,
     ) where
         F: Field + TwoAdicField,
-        EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+        EF: ExtensionField<F> + TwoAdicField,
     {
         let ctx = match self {
             Self::Naive => StirEvalContext::Naive {
@@ -140,7 +140,7 @@ impl FoldType {
     ) -> Vec<Vec<EF>>
     where
         F: Field + TwoAdicField,
-        EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+        EF: ExtensionField<F> + TwoAdicField,
     {
         match self {
             Self::Naive => {

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -1,4 +1,4 @@
-use p3_field::{ExtensionField, Field, PrimeCharacteristicRing, PrimeField64, TwoAdicField};
+use p3_field::{ExtensionField, Field, PrimeField64, TwoAdicField};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -30,18 +30,20 @@ use crate::{
 ///
 /// The sumcheck protocol ensures that the claimed sum is correct.
 #[derive(Debug, Clone)]
-pub struct SumcheckSingle<F> {
+pub struct SumcheckSingle<F, EF> {
     /// Evaluations of the polynomial `p(X)`.
-    evaluation_of_p: EvaluationsList<F>,
+    evaluation_of_p: EvaluationsList<EF>,
     /// Evaluations of the equality polynomial used for enforcing constraints.
-    weights: EvaluationsList<F>,
+    weights: EvaluationsList<EF>,
     /// Accumulated sum incorporating equality constraints.
-    sum: F,
+    sum: EF,
+    phantom: std::marker::PhantomData<F>,
 }
 
-impl<F> SumcheckSingle<F>
+impl<F, EF> SumcheckSingle<F, EF>
 where
     F: Field,
+    EF: ExtensionField<F>,
 {
     /// Constructs a new `SumcheckSingle` instance from polynomial coefficients.
     ///
@@ -52,15 +54,16 @@ where
     ///
     /// The provided `Statement` encodes constraints that contribute to the final sumcheck equation.
     pub fn new(
-        coeffs: CoefficientList<F>,
-        statement: &Statement<F>,
-        combination_randomness: F,
+        coeffs: CoefficientList<EF>,
+        statement: &Statement<EF>,
+        combination_randomness: EF,
     ) -> Self {
         let (weights, sum) = statement.combine(combination_randomness);
         Self {
             evaluation_of_p: coeffs.into(),
             weights,
             sum,
+            phantom: std::marker::PhantomData,
         }
     }
 
@@ -88,9 +91,9 @@ where
     /// where `w_{z_i}(X)` represents the constraint encoding at point `z_i`.
     pub fn add_new_equality(
         &mut self,
-        points: &[MultilinearPoint<F>],
-        evaluations: &[F],
-        combination_randomness: &[F],
+        points: &[MultilinearPoint<EF>],
+        evaluations: &[EF],
+        combination_randomness: &[EF],
     ) {
         assert_eq!(combination_randomness.len(), points.len());
         assert_eq!(combination_randomness.len(), evaluations.len());
@@ -117,7 +120,7 @@ where
     /// - `b` represents points in `{0,1,2}^1`.
     /// - `w(b, X)` are the generic weights applied to `p(b, X)`.
     /// - `h(X)` is a quadratic polynomial.
-    pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
+    pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<EF> {
         assert!(self.num_variables() >= 1);
 
         #[cfg(feature = "parallel")]
@@ -135,7 +138,7 @@ where
                 (p_0 * eq_0, p_1 * eq_1)
             })
             .reduce(
-                || (F::ZERO, F::ZERO),
+                || (EF::ZERO, EF::ZERO),
                 |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
             );
 
@@ -189,22 +192,21 @@ where
     /// - Returns the sampled folding randomness values used in each reduction step.
     pub fn compute_sumcheck_polynomials<S>(
         &mut self,
-        prover_state: &mut ProverState<F, F::PrimeSubfield>,
+        prover_state: &mut ProverState<EF, F>,
         folding_factor: usize,
         pow_bits: f64,
-    ) -> ProofResult<MultilinearPoint<F>>
+    ) -> ProofResult<MultilinearPoint<EF>>
     where
-        F: Field + ExtensionField<<F as PrimeCharacteristicRing>::PrimeSubfield> + TwoAdicField,
-        F::PrimeSubfield: PrimeField64,
+        F: PrimeField64 + TwoAdicField,
+        EF: ExtensionField<F> + TwoAdicField,
         S: PowStrategy,
-        <F as PrimeCharacteristicRing>::PrimeSubfield: TwoAdicField,
     {
         let mut res = Vec::with_capacity(folding_factor);
 
         for _ in 0..folding_factor {
             let sumcheck_poly = self.compute_sumcheck_polynomial();
             prover_state.add_scalars(sumcheck_poly.evaluations())?;
-            let [folding_randomness]: [F; 1] = prover_state.challenge_scalars()?;
+            let [folding_randomness]: [EF; 1] = prover_state.challenge_scalars()?;
             res.push(folding_randomness);
 
             // Do PoW if needed
@@ -212,7 +214,7 @@ where
                 prover_state.challenge_pow::<S>(pow_bits)?;
             }
 
-            self.compress(F::ONE, &folding_randomness.into(), &sumcheck_poly);
+            self.compress(EF::ONE, &folding_randomness.into(), &sumcheck_poly);
         }
 
         res.reverse();
@@ -242,16 +244,16 @@ where
     /// - Updates `sum` using `sumcheck_poly`.
     pub fn compress(
         &mut self,
-        combination_randomness: F, // Scale the initial point
-        folding_randomness: &MultilinearPoint<F>,
-        sumcheck_poly: &SumcheckPolynomial<F>,
+        combination_randomness: EF, // Scale the initial point
+        folding_randomness: &MultilinearPoint<EF>,
+        sumcheck_poly: &SumcheckPolynomial<EF>,
     ) {
         assert_eq!(folding_randomness.num_variables(), 1);
         assert!(self.num_variables() >= 1);
 
         let randomness = folding_randomness.0[0];
 
-        let fold_chunk = |slice: &[F]| -> F { (slice[1] - slice[0]) * randomness + slice[0] };
+        let fold_chunk = |slice: &[EF]| -> EF { (slice[1] - slice[0]) * randomness + slice[0] };
 
         #[cfg(feature = "parallel")]
         let (evaluations_of_p, evaluations_of_eq) = {

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -156,7 +156,9 @@ where
                 // Now we need to add the contribution of p(x) * eq(x)
                 (p_0 * eq_0, p_1 * eq_1)
             })
-            .fold((F::ZERO, F::ZERO), |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2));
+            .fold((EF::ZERO, EF::ZERO), |(a0, a2), (b0, b2)| {
+                (a0 + b0, a2 + b2)
+            });
 
         // Compute the middle coefficient using sum rule: sum = 2 * c0 + c1 + c2
         let c1 = self.sum - c0.double() - c2;

--- a/src/whir/committer/reader.rs
+++ b/src/whir/committer/reader.rs
@@ -17,12 +17,12 @@ pub struct ParsedCommitment<F, D> {
 pub struct CommitmentReader<'a, EF, F, H, C, PowStrategy>(&'a WhirConfig<EF, F, H, C, PowStrategy>)
 where
     F: Field + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>;
+    EF: ExtensionField<F> + TwoAdicField;
 
 impl<'a, EF, F, H, C, PS> CommitmentReader<'a, EF, F, H, C, PS>
 where
     F: Field + TwoAdicField + PrimeField64,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
 {
     pub const fn new(params: &'a WhirConfig<EF, F, H, C, PS>) -> Self {
         Self(params)

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -23,12 +23,12 @@ use crate::{
 pub struct CommitmentWriter<EF, F, H, C, PowStrategy>(WhirConfig<EF, F, H, C, PowStrategy>)
 where
     F: Field + TwoAdicField + PrimeField64,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>;
+    EF: ExtensionField<F> + TwoAdicField;
 
 impl<EF, F, H, C, PS> CommitmentWriter<EF, F, H, C, PS>
 where
     F: Field + TwoAdicField + PrimeField64,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
 {
     pub const fn new(params: WhirConfig<EF, F, H, C, PS>) -> Self {
         Self(params)
@@ -70,7 +70,7 @@ where
         );
 
         // Convert to extension field (for future rounds)
-        let folded_evals: Vec<_> = evals.into_iter().map(EF::from_prime_subfield).collect();
+        let folded_evals: Vec<_> = evals.into_iter().map(EF::from).collect();
 
         // Determine leaf size based on folding factor.
         let fold_size = 1 << self.0.folding_factor.at_round(0);

--- a/src/whir/parameters.rs
+++ b/src/whir/parameters.rs
@@ -22,7 +22,7 @@ pub struct RoundConfig {
 pub struct WhirConfig<EF, F, H, C, PowStrategy>
 where
     F: Field + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
 {
     pub mv_parameters: MultivariateParameters<EF>,
     pub soundness_type: SoundnessType,
@@ -61,7 +61,7 @@ where
 impl<EF, F, H, C, PowStrategy> WhirConfig<EF, F, H, C, PowStrategy>
 where
     F: Field + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
 {
     #[allow(clippy::too_many_lines)]
     pub fn new(

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -30,11 +30,11 @@ pub type Leafs<F> = Vec<Vec<F>>;
 pub(crate) struct RoundState<EF, F, const DIGEST_ELEMS: usize>
 where
     F: Field + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
 {
     pub(crate) round: usize,
     pub(crate) domain: Domain<EF, F>,
-    pub(crate) sumcheck_prover: Option<SumcheckSingle<EF>>,
+    pub(crate) sumcheck_prover: Option<SumcheckSingle<F, EF>>,
     pub(crate) folding_randomness: MultilinearPoint<EF>,
     pub(crate) coefficients: CoefficientList<EF>,
     pub(crate) prev_merkle_prover_data:
@@ -50,12 +50,12 @@ where
 pub struct Prover<EF, F, H, C, PowStrategy>(pub WhirConfig<EF, F, H, C, PowStrategy>)
 where
     F: Field + TwoAdicField + PrimeField64,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>;
+    EF: ExtensionField<F> + TwoAdicField;
 
 impl<EF, F, H, C, PS> Prover<EF, F, H, C, PS>
 where
     F: Field + TwoAdicField + PrimeField64,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
     PS: PowStrategy,
 {
     fn validate_parameters(&self) -> bool {

--- a/src/whir/stir_evaluations.rs
+++ b/src/whir/stir_evaluations.rs
@@ -94,9 +94,6 @@ where
                 let coset_generator_inv =
                     domain_gen_inv.exp_u64((domain_size / coset_domain_size) as u64);
 
-                // Precompute inverse of 2
-                let two_inv = F::TWO.inverse();
-
                 // Evaluate folded values for each challenge index
                 stir_evaluations.extend(stir_challenges_indexes.iter().zip(answers).map(
                     |(index, answers)| {
@@ -109,7 +106,6 @@ where
                             &folding_randomness.0,
                             coset_offset_inv,
                             coset_generator_inv,
-                            two_inv,
                             folding_factor.at_round(*round),
                         )
                     },
@@ -251,12 +247,11 @@ mod tests {
         // folding step:
         //   g = (f0 + f1 + r * (f0 - f1) * offset⁻¹ * g⁰⁻¹) / 2
         //     = (f0 + f1 + r * (f0 - f1) * offset⁻¹) / 2
-        let two_inv = BabyBear::from_u64(2).inverse();
         let diff = f0 - f1;
         let offset_inv = domain_gen_inv.exp_u64(1);
         let left = f0 + f1;
         let right = r * diff * offset_inv;
-        let expected = two_inv * (left + right);
+        let expected = (left + right).halve();
 
         let context = StirEvalContext::Naive {
             domain_size,

--- a/src/whir/utils.rs
+++ b/src/whir/utils.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use p3_field::{ExtensionField, Field, PrimeCharacteristicRing, PrimeField64, TwoAdicField};
+use p3_field::{ExtensionField, PrimeField64, TwoAdicField};
 
 use crate::{
     fiat_shamir::{UnitToBytes, errors::ProofResult, prover::ProverState},
@@ -43,19 +43,18 @@ where
 /// A utility function to sample Out-of-Domain (OOD) points and evaluate them.
 ///
 /// This should be used on the prover side.
-pub fn sample_ood_points<F, E>(
-    prover_state: &mut ProverState<F, F::PrimeSubfield>,
+pub fn sample_ood_points<F, EF, E>(
+    prover_state: &mut ProverState<EF, F>,
     num_samples: usize,
     num_variables: usize,
     evaluate_fn: E,
-) -> ProofResult<(Vec<F>, Vec<F>)>
+) -> ProofResult<(Vec<EF>, Vec<EF>)>
 where
-    F: Field + ExtensionField<<F as PrimeCharacteristicRing>::PrimeSubfield> + TwoAdicField,
-    F::PrimeSubfield: PrimeField64,
-    E: Fn(&MultilinearPoint<F>) -> F,
-    <F as PrimeCharacteristicRing>::PrimeSubfield: TwoAdicField,
+    F: PrimeField64 + TwoAdicField,
+    EF: ExtensionField<F> + TwoAdicField,
+    E: Fn(&MultilinearPoint<EF>) -> EF,
 {
-    let mut ood_points = vec![F::ZERO; num_samples];
+    let mut ood_points = vec![EF::ZERO; num_samples];
     let mut ood_answers = Vec::with_capacity(num_samples);
 
     if num_samples > 0 {

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -30,7 +30,7 @@ use crate::{
 pub struct Verifier<'a, EF, F, H, C, PowStrategy>
 where
     F: Field + TwoAdicField,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
 {
     params: &'a WhirConfig<EF, F, H, C, PowStrategy>,
 }
@@ -38,7 +38,7 @@ where
 impl<'a, EF, F, H, C, PS> Verifier<'a, EF, F, H, C, PS>
 where
     F: Field + TwoAdicField + PrimeField64,
-    EF: ExtensionField<F> + TwoAdicField<PrimeSubfield = F>,
+    EF: ExtensionField<F> + TwoAdicField,
     PS: PowStrategy,
 {
     pub const fn new(params: &'a WhirConfig<EF, F, H, C, PS>) -> Self {


### PR DESCRIPTION
Simplified the trait system by removing all references to `PrimeSubField`.

Also removed all references to `two_inv` as it's quite a bit cheaper to just use the `.halve()` function. (Both `.halve()` is cheaper than multiplication and it avoids needing to do an inversion)

I ran the test suite and nothing seems to have gone wrong. I did have to slightly rework one or two traits to depend on both `EF` and `F` instead of just `EF`.

In general I'd recommend avoiding `PrimeSubField` unless it's absolutely necessary.

The other minor change is removing `EF::PrimeSubfield::DIMENSION` (which became `F::DIMENSION`) as that's just always equal to `1` as F is the smallest field here.