### PR TITLE
reduce proof size by sending coeffs earlier

### DIFF
--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -11,6 +11,9 @@ use crate::whir::{
 
 pub mod errors;
 
+/// Each WHIR steps folds the polymomial, which reduces the number of variables.
+/// As soon as the number of variables is less than or equal to `MAX_NUM_VARIABLES_TO_SEND_COEFFS`,
+/// the prover sends directly the coefficients of the polynomial.
 const MAX_NUM_VARIABLES_TO_SEND_COEFFS: usize = 6;
 
 /// Computes the default maximum proof-of-work (PoW) bits.
@@ -261,12 +264,11 @@ impl FoldingFactor {
     #[must_use]
     pub fn compute_number_of_rounds(&self, num_variables: usize) -> (usize, usize) {
         match self {
-            FoldingFactor::Constant(factor) => {
+            Self::Constant(factor) => {
                 if num_variables <= MAX_NUM_VARIABLES_TO_SEND_COEFFS {
                     // the first folding is mandatory in the current implem (TODO don't fold, send directly the polynomial)
                     return (0, num_variables - factor);
                 }
-
                 // Starting from `num_variables`, each round reduces the number of variables by `factor`. As soon as the
                 // number of variables is less of equal than `MAX_NUM_VARIABLES_TO_SEND_COEFFS`, we stop folding and the
                 // prover sends directly the coefficients of the polynomial.
@@ -276,7 +278,7 @@ impl FoldingFactor {
                 // The -1 accounts for the fact that the last round does not require another folding.
                 (num_rounds - 1, final_sumcheck_rounds)
             }
-            FoldingFactor::ConstantFromSecondRound(first_round_factor, factor) => {
+            Self::ConstantFromSecondRound(first_round_factor, factor) => {
                 // Compute the number of variables remaining after the first round.
                 let nv_except_first_round = num_variables - *first_round_factor;
                 if nv_except_first_round < MAX_NUM_VARIABLES_TO_SEND_COEFFS {

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -11,6 +11,8 @@ use crate::whir::{
 
 pub mod errors;
 
+const MAX_NUM_VARIABLES_TO_SEND_COEFFS: usize = 6;
+
 /// Computes the default maximum proof-of-work (PoW) bits.
 ///
 /// This function determines the PoW security level based on the number of variables
@@ -259,37 +261,37 @@ impl FoldingFactor {
     #[must_use]
     pub fn compute_number_of_rounds(&self, num_variables: usize) -> (usize, usize) {
         match self {
-            Self::Constant(factor) => {
-                // The number of remaining variables that cannot be fully folded.
-                let final_sumcheck_rounds = num_variables % factor;
-
-                // Compute the number of WHIR rounds by subtracting the final sumcheck rounds
-                // and dividing by the folding factor. The -1 accounts for the fact that the last
-                // round does not require another folding.
-                (
-                    (num_variables - final_sumcheck_rounds) / factor - 1,
-                    final_sumcheck_rounds,
-                )
-            }
-            Self::ConstantFromSecondRound(first_round_factor, factor) => {
-                // Compute the number of variables remaining after the first round.
-                let nv_except_first_round = num_variables - *first_round_factor;
-
-                // If the remaining variables are too few for a full folding round,
-                // treat it as a single final sumcheck step.
-                if nv_except_first_round < *factor {
-                    return (0, nv_except_first_round);
+            FoldingFactor::Constant(factor) => {
+                if num_variables <= MAX_NUM_VARIABLES_TO_SEND_COEFFS {
+                    // the first folding is mandatory in the current implem (TODO don't fold, send directly the polynomial)
+                    return (0, num_variables - factor);
                 }
 
-                // The number of remaining variables that cannot be fully folded.
-                let final_sumcheck_rounds = nv_except_first_round % *factor;
-
-                // Compute the number of WHIR rounds by dividing the remaining variables
-                // (excluding the first round) by the folding factor.
-                (
-                    (nv_except_first_round - final_sumcheck_rounds) / factor,
-                    final_sumcheck_rounds,
-                )
+                // Starting from `num_variables`, each round reduces the number of variables by `factor`. As soon as the
+                // number of variables is less of equal than `MAX_NUM_VARIABLES_TO_SEND_COEFFS`, we stop folding and the
+                // prover sends directly the coefficients of the polynomial.
+                let num_rounds =
+                    (num_variables - MAX_NUM_VARIABLES_TO_SEND_COEFFS).div_ceil(*factor);
+                let final_sumcheck_rounds = num_variables - num_rounds * factor;
+                // The -1 accounts for the fact that the last round does not require another folding.
+                (num_rounds - 1, final_sumcheck_rounds)
+            }
+            FoldingFactor::ConstantFromSecondRound(first_round_factor, factor) => {
+                // Compute the number of variables remaining after the first round.
+                let nv_except_first_round = num_variables - *first_round_factor;
+                if nv_except_first_round < MAX_NUM_VARIABLES_TO_SEND_COEFFS {
+                    // This case is equivalent to Constant(first_round_factor)
+                    // the first folding is mandatory in the current implem (TODO don't fold, send directly the polynomial)
+                    return (0, nv_except_first_round);
+                }
+                // Starting from `num_variables`, the first round reduces the number of variables by `first_round_factor`,
+                // and the next ones by `factor`. As soon as the number of variables is less of equal than
+                // `MAX_NUM_VARIABLES_TO_SEND_COEFFS`, we stop folding and the prover sends directly the coefficients of the polynomial.
+                let num_rounds =
+                    (nv_except_first_round - MAX_NUM_VARIABLES_TO_SEND_COEFFS).div_ceil(*factor);
+                let final_sumcheck_rounds = nv_except_first_round - num_rounds * factor;
+                // No need to minus 1 because the initial round is already excepted out
+                (num_rounds, final_sumcheck_rounds)
             }
         }
     }
@@ -434,13 +436,66 @@ mod tests {
 
     #[test]
     fn test_compute_number_of_rounds() {
-        let factor = FoldingFactor::Constant(2);
-        assert_eq!(factor.compute_number_of_rounds(6), (2, 0)); // 6 - 2 rounds, no remainder
-        assert_eq!(factor.compute_number_of_rounds(7), (2, 1)); // 7 - 2 rounds, 1 remainder
+        let constant_factor = 3;
+        let factor = FoldingFactor::Constant(constant_factor);
+        assert_eq!(
+            factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS - 1),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS - constant_factor - 1)
+        );
+        assert_eq!(
+            factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS - constant_factor)
+        );
+        assert_eq!(
+            factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS + 1),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS - constant_factor + 1)
+        );
+        assert_eq!(
+            factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS + constant_factor),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS)
+        );
+        assert_eq!(
+            factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS + constant_factor + 1),
+            (1, MAX_NUM_VARIABLES_TO_SEND_COEFFS - constant_factor + 1)
+        );
+        assert_eq!(
+            factor.compute_number_of_rounds(
+                MAX_NUM_VARIABLES_TO_SEND_COEFFS + constant_factor * 2 + 1
+            ),
+            (2, MAX_NUM_VARIABLES_TO_SEND_COEFFS - constant_factor + 1)
+        );
 
-        let variable_factor = FoldingFactor::ConstantFromSecondRound(3, 2);
-        assert_eq!(variable_factor.compute_number_of_rounds(7), (2, 0)); // 7 variables, first round uses 3, then 2 per round
-        assert_eq!(variable_factor.compute_number_of_rounds(8), (2, 1)); // 8 variables, remainder 1
+        let initial_factor = 4;
+        let next_factor = 3;
+        let variable_factor = FoldingFactor::ConstantFromSecondRound(initial_factor, next_factor);
+        assert_eq!(
+            variable_factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS - 1),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS - initial_factor - 1)
+        );
+        assert_eq!(
+            variable_factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS - initial_factor)
+        );
+        assert_eq!(
+            variable_factor.compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS + 1),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS - initial_factor + 1)
+        );
+        assert_eq!(
+            variable_factor
+                .compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS + initial_factor),
+            (0, MAX_NUM_VARIABLES_TO_SEND_COEFFS)
+        );
+        assert_eq!(
+            variable_factor
+                .compute_number_of_rounds(MAX_NUM_VARIABLES_TO_SEND_COEFFS + initial_factor + 1),
+            (1, MAX_NUM_VARIABLES_TO_SEND_COEFFS - next_factor + 1)
+        );
+        assert_eq!(
+            variable_factor.compute_number_of_rounds(
+                MAX_NUM_VARIABLES_TO_SEND_COEFFS + initial_factor + next_factor + 1
+            ),
+            (2, MAX_NUM_VARIABLES_TO_SEND_COEFFS - next_factor + 1)
+        );
     }
 
     #[test]

--- a/src/whir/parameters.rs
+++ b/src/whir/parameters.rs
@@ -314,7 +314,8 @@ mod tests {
     type Poseidon2Sponge<Perm24> = PaddingFreeSponge<Perm24, 24, 16, 8>;
 
     /// Generates default WHIR parameters
-    fn default_whir_params() -> ProtocolParameters<Poseidon2Sponge<u8>, Poseidon2Compression<u8>> {
+    const fn default_whir_params()
+    -> ProtocolParameters<Poseidon2Sponge<u8>, Poseidon2Compression<u8>> {
         ProtocolParameters {
             initial_statement: true,
             security_level: 100,


### PR DESCRIPTION
As soon as we reach a number of variables <= K in the WHIR steps, we stop folding and send directly the coefficients of the polynomial. In the current implem, K = folding_factor - 1 . But in practice folding_factor is often = 4, and we could send the coeffs earlier, ie use a greater value for K.

In my PR K is called "MAX_NUM_VARIABLES_TO_SEND_COEFFS" (TODO find a better name)
Ideally K should not be harcoded, because the optimal value depends on several factors.

```
cargo run --release --package whir-p3 --bin main -- --security-level=128 --num-variables=22 --sec=JohnsonBound
```

Before:
Before: 278.6 KiB
After: 265.8 KiB
