### PR TITLE
Faster Wavelet Transform

### DIFF
--- a/benches/whir.rs
+++ b/benches/whir.rs
@@ -5,23 +5,25 @@ use whir_p3::{
 };
 
 fn benchmark_whir(c: &mut Criterion) {
-    let num_variables = 18;
+    let polynomial_sizes = [16, 18, 20, 22];
     let folding_factor = FoldingFactor::Constant(4);
     let num_points = 2;
     let soundness_type = SecurityAssumption::UniqueDecoding;
     let pow_bits = 10;
 
-    c.bench_function("whir_end_to_end", |b| {
-        b.iter(|| {
-            make_whir_things(
-                num_variables,
-                folding_factor,
-                num_points,
-                soundness_type,
-                pow_bits,
-            );
+    for num_variables in polynomial_sizes {
+        c.bench_function(&format!("whir_end_to_end_size {num_variables}"), |b| {
+            b.iter(|| {
+                make_whir_things(
+                    num_variables,
+                    folding_factor,
+                    num_points,
+                    soundness_type,
+                    pow_bits,
+                );
+            });
         });
-    });
+    }
 }
 
 criterion_group!(benches, benchmark_whir);

--- a/src/ntt/wavelet.rs
+++ b/src/ntt/wavelet.rs
@@ -1,7 +1,9 @@
 use p3_field::{Field, PackedValue};
 use p3_matrix::{Matrix, dense::RowMajorMatrixViewMut, util::reverse_matrix_index_bits};
 use p3_util::log2_strict_usize;
-use {super::utils::workload_size, rayon::prelude::*};
+use rayon::prelude::*;
+
+use super::utils::workload_size;
 
 /// Perform the inverse wavelet transform on each row of a matrix.
 ///

--- a/src/ntt/wavelet.rs
+++ b/src/ntt/wavelet.rs
@@ -1,6 +1,7 @@
 use p3_field::{Field, PackedValue};
 use p3_matrix::{Matrix, dense::RowMajorMatrixViewMut, util::reverse_matrix_index_bits};
 use p3_util::log2_strict_usize;
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 use super::utils::workload_size;

--- a/src/ntt/wavelet.rs
+++ b/src/ntt/wavelet.rs
@@ -1,7 +1,6 @@
 use p3_field::{Field, PackedValue};
 use p3_matrix::{Matrix, dense::RowMajorMatrixViewMut, util::reverse_matrix_index_bits};
 use p3_util::log2_strict_usize;
-#[cfg(feature = "parallel")]
 use {super::utils::workload_size, rayon::prelude::*};
 
 /// Perform the inverse wavelet transform on each row of a matrix.

--- a/src/ntt/wavelet.rs
+++ b/src/ntt/wavelet.rs
@@ -1,5 +1,6 @@
-use p3_field::Field;
-use p3_matrix::{Matrix, dense::RowMajorMatrixViewMut};
+use p3_field::{Field, PackedValue};
+use p3_matrix::{Matrix, dense::RowMajorMatrixViewMut, util::reverse_matrix_index_bits};
+use p3_util::log2_strict_usize;
 #[cfg(feature = "parallel")]
 use {super::utils::workload_size, rayon::prelude::*};
 
@@ -131,88 +132,43 @@ pub fn inverse_wavelet_transform_batch<F: Field>(
 /// Assumes the number of rows is a power of two.
 pub fn wavelet_transform<F: Field>(mat: &mut RowMajorMatrixViewMut<'_, F>) {
     let height = mat.height();
-    debug_assert!(height.is_power_of_two());
-    wavelet_transform_batch(mat, height);
+    let log_height = log2_strict_usize(height);
+    let half_log = log_height / 2;
+
+    // Start by reversing the matrix indices.
+    reverse_matrix_index_bits(mat);
+
+    for i in 0..half_log {
+        let block_size = 1 << (log_height - i);
+
+        // Apply the wavelet kernel on blocks of size `block_size`.
+        wavelet_kernel(mat, block_size);
+    }
+
+    // Start by reversing the matrix indices.
+    reverse_matrix_index_bits(mat);
+    for i in half_log..log_height {
+        let block_size = 1 << (i + 1);
+
+        // Apply the wavelet kernel on blocks of size `block_size`.
+        wavelet_kernel(mat, block_size);
+    }
 }
 
-pub fn wavelet_transform_batch<F: Field>(mat: &mut RowMajorMatrixViewMut<'_, F>, size: usize) {
-    debug_assert!(mat.height() % size == 0 && size.is_power_of_two());
-
-    #[cfg(feature = "parallel")]
-    if mat.height() > workload_size::<F>() && mat.height() != size {
-        let chunk_rows = size * std::cmp::max(1, workload_size::<F>() / size);
-        mat.par_row_chunks_mut(chunk_rows)
-            .for_each(|mut chunk| wavelet_transform_batch(&mut chunk, size));
-        return;
-    }
-
-    match size {
-        0 | 1 => {}
-        2 => {
-            for v in mat.row_chunks_exact_mut(2) {
-                v.values[1] += v.values[0];
-            }
-        }
-        4 => {
-            for v in mat.row_chunks_exact_mut(4) {
-                v.values[1] += v.values[0];
-                v.values[3] += v.values[2];
-                v.values[2] += v.values[0];
-                v.values[3] += v.values[1];
-            }
-        }
-        8 => {
-            for v in mat.row_chunks_exact_mut(8) {
-                v.values[1] += v.values[0];
-                v.values[3] += v.values[2];
-                v.values[2] += v.values[0];
-                v.values[3] += v.values[1];
-                v.values[5] += v.values[4];
-                v.values[7] += v.values[6];
-                v.values[6] += v.values[4];
-                v.values[7] += v.values[5];
-                v.values[4] += v.values[0];
-                v.values[5] += v.values[1];
-                v.values[6] += v.values[2];
-                v.values[7] += v.values[3];
-            }
-        }
-        16 => {
-            for mut v in mat.row_chunks_exact_mut(16) {
-                for v in v.row_chunks_exact_mut(4) {
-                    v.values[1] += v.values[0];
-                    v.values[3] += v.values[2];
-                    v.values[2] += v.values[0];
-                    v.values[3] += v.values[1];
-                }
-                let (a, mut v) = v.split_rows_mut(4);
-                let (b, mut v) = v.split_rows_mut(4);
-                let (c, d) = v.split_rows_mut(4);
-                for i in 0..4 {
-                    b.values[i] += a.values[i];
-                    d.values[i] += c.values[i];
-                    c.values[i] += a.values[i];
-                    d.values[i] += b.values[i];
-                }
-            }
-        }
-        n => {
-            let n1 = 1 << (n.trailing_zeros() / 2);
-            let n2 = size / n1;
-
-            wavelet_transform_batch(mat, n1);
-            mat.par_row_chunks_exact_mut(n1 * n2).for_each(|matrix| {
-                let m = RowMajorMatrixViewMut::new(matrix.values, n1).transpose();
-                matrix.values.copy_from_slice(&m.values);
-            });
-
-            wavelet_transform_batch(mat, n2);
-            mat.par_row_chunks_exact_mut(n1 * n2).for_each(|matrix| {
-                let m = RowMajorMatrixViewMut::new(matrix.values, n2).transpose();
-                matrix.values.copy_from_slice(&m.values);
-            });
-        }
-    }
+/// Apply the wavelet kernel on blocks of a given size.
+fn wavelet_kernel<F: Field>(mat: &mut RowMajorMatrixViewMut<'_, F>, block_size: usize) {
+    let half_block_size = block_size / 2;
+    mat.par_row_chunks_exact_mut(block_size).for_each(|block| {
+        let (lo, hi) = block.values.split_at_mut(half_block_size);
+        let (pack_lo, sfx_lo) = F::Packing::pack_slice_with_suffix_mut(lo);
+        let (pack_hi, sfx_hi) = F::Packing::pack_slice_with_suffix_mut(hi);
+        pack_hi.iter_mut().zip(pack_lo).for_each(|(hi, lo)| {
+            *hi += *lo;
+        });
+        sfx_hi.iter_mut().zip(sfx_lo).for_each(|(hi, lo)| {
+            *hi += *lo;
+        });
+    });
 }
 
 #[cfg(test)]
@@ -366,56 +322,6 @@ mod tests {
         // Verify last element has accumulated all previous values
         let expected_last = (1..=size).sum::<u64>();
         assert_eq!(mat.values[size as usize - 1], F::from_u64(expected_last));
-    }
-
-    #[test]
-    fn test_wavelet_transform_batch_parallel_chunks() {
-        // Define the size for the wavelet transform batch
-        let batch_size = 2_i32.pow(20) as usize;
-        // Ensure values.len() > size to enter parallel execution
-        let total_size = batch_size * 4;
-        let values = (1..=total_size as u64).map(F::from_u64).collect::<Vec<_>>();
-
-        // Keep a copy to compare later
-        let original_values = values.clone();
-
-        let mut mat = RowMajorMatrix::new_col(values);
-
-        // Run batch transform on 256-sized chunks
-        wavelet_transform_batch(&mut mat.as_view_mut(), batch_size);
-
-        // Verify that the first chunk has been transformed correctly
-        let mut mat1 = RowMajorMatrix::new_col(original_values[..batch_size].to_vec());
-
-        wavelet_transform_batch(&mut mat1.as_view_mut(), batch_size);
-        assert_eq!(mat.values[..batch_size], mat1.values);
-
-        // Ensure that the transformation occurred separately for each chunk
-        for i in 1..4 {
-            let start = i * batch_size;
-            let end = start + batch_size;
-
-            let mut mat_loop = RowMajorMatrix::new_col(original_values[start..end].to_vec());
-            wavelet_transform_batch(&mut mat_loop.as_view_mut(), batch_size);
-
-            assert_eq!(
-                mat.values[start..end],
-                mat_loop.values,
-                "Mismatch in chunk {i}"
-            );
-        }
-
-        // Ensure the first element remains unchanged
-        assert_eq!(mat.values[0], F::from_u64(1));
-
-        // Ensure the last element has accumulated all values from its own chunk
-        let expected_last_chunk_sum =
-            (total_size as u64 - batch_size as u64 + 1..=total_size as u64).sum::<u64>();
-        assert_eq!(
-            mat.values[total_size - 1],
-            F::from_u64(expected_last_chunk_sum),
-            "Final element mismatch"
-        );
     }
 
     #[test]

--- a/src/ntt/wavelet.rs
+++ b/src/ntt/wavelet.rs
@@ -138,7 +138,7 @@ pub fn wavelet_transform<F: Field>(mat: &mut RowMajorMatrixViewMut<'_, F>) {
 
     // When applying the wavelet transform in parallel, we want to try and split up the work
     // into medium sized chunks which fit nicely on the different cores.
-    // As a rough rule of thumb, we will use chuncks of size `workload_size::<F>()` unless the
+    // As a rough rule of thumb, we will use chunks of size `workload_size::<F>()` unless the
     // transform is much larger than this.
     let num_par_rows = (workload_size::<F>() / mat.width())
         .next_power_of_two()


### PR DESCRIPTION
I rewrote the `wavelet_transform` code to make better use of SIMD instructions and do less data fiddling. This is the first of several PR's aiming to address #37.

Seems to give around a 10% speed up on the size 18 end-end test and 15-20% speed ups on the size 20 and 22 tests.

For the wavelet benches, the results are slightly confusingly mixed.

I'm getting roughly 20% speed ups for sizes `10, 12`, basically no change for `14`, a 40% slow down for size `16`, a 60% speed up for size `18` and a `75%` speed up for size `20`.

I'm really not sure what's going on with the size 16 case. For some reason the current code seems to be really good in exactly that case. It could also be something strange happening with the benchmark? I played around with it a little but couldn't work it out/reproduce that speed.

At any rate I think this is still worth doing.

I also modified the code so it can accept a matrix of any width not just width `1`. (The current code implicitly only works in that case). In particular this means that if we want to apply the transform to an extension field matrix, it will be much much faster to first convert the matrix to a base field one. (As this lets us take advantage of packings).

I haven't made that change in the rest of the code yet but if this gets accepted/merged I'll make an issue with that in mind.

Similarly, I currently have not touched the inverse transform but, for obvious reasons, the code here will translate to that case almost identically. (I'll put it in another PR once we merge this one)