### PR TITLE
Further Work on Eval Eq

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -23,10 +23,10 @@ use whir_p3::{
     },
 };
 
-type _F = Goldilocks;
-type _EF = BinomialExtensionField<_F, 2>;
-type F = BabyBear;
-type EF = BinomialExtensionField<F, 5>;
+type F = Goldilocks;
+type EF = BinomialExtensionField<F, 2>;
+type _F = BabyBear;
+type _EF = BinomialExtensionField<_F, 5>;
 type ByteHash = Blake3;
 type FieldHash = SerializingHasher<ByteHash>;
 type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use p3_baby_bear::BabyBear;
 use p3_blake3::Blake3;
 use p3_dft::Radix2DitParallel;
 use p3_field::{PrimeCharacteristicRing, extension::BinomialExtensionField};
@@ -22,8 +23,10 @@ use whir_p3::{
     },
 };
 
-type F = Goldilocks;
-type EF = BinomialExtensionField<F, 2>;
+type _F = Goldilocks;
+type _EF = BinomialExtensionField<_F, 2>;
+type F = BabyBear;
+type EF = BinomialExtensionField<F, 5>;
 type ByteHash = Blake3;
 type FieldHash = SerializingHasher<ByteHash>;
 type MyCompress = CompressionFunctionFromHasher<ByteHash, 2, 32>;

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -68,7 +68,7 @@ where
         statement: &Statement<EF>,
         combination_randomness: EF,
     ) -> Self {
-        let (weights, sum) = statement.combine(combination_randomness);
+        let (weights, sum) = statement.combine::<F>(combination_randomness);
         Self {
             evaluation_of_p: EvaluationStorage::Base(coeffs.to_evaluations()),
             weights,
@@ -91,7 +91,7 @@ where
         statement: &Statement<EF>,
         combination_randomness: EF,
     ) -> Self {
-        let (weights, sum) = statement.combine(combination_randomness);
+        let (weights, sum) = statement.combine::<F>(combination_randomness);
         Self {
             evaluation_of_p: EvaluationStorage::Base(evals),
             weights,
@@ -113,7 +113,7 @@ where
         statement: &Statement<EF>,
         combination_randomness: EF,
     ) -> Self {
-        let (weights, sum) = statement.combine(combination_randomness);
+        let (weights, sum) = statement.combine::<F>(combination_randomness);
         Self {
             evaluation_of_p: EvaluationStorage::Extension(coeffs.to_evaluations::<F>()),
             weights,
@@ -136,7 +136,7 @@ where
         statement: &Statement<EF>,
         combination_randomness: EF,
     ) -> Self {
-        let (weights, sum) = statement.combine(combination_randomness);
+        let (weights, sum) = statement.combine::<F>(combination_randomness);
         Self {
             evaluation_of_p: EvaluationStorage::Extension(evals),
             weights,
@@ -184,7 +184,7 @@ where
             .iter()
             .zip(combination_randomness.iter().zip(evaluations.iter()))
             .for_each(|(point, (&rand, &eval))| {
-                eval_eq(&point.0, self.weights.evals_mut(), rand);
+                eval_eq::<F, EF>(&point.0, self.weights.evals_mut(), rand);
                 self.sum += rand * eval;
             });
     }

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -1901,7 +1901,7 @@ mod tests {
 
         // Expected weight table updated using eq(X) = weight × eq_at_point(point)
         let mut expected_weights = vec![EF4::ZERO; 2];
-        eval_eq(&point.0, &mut expected_weights, weight);
+        eval_eq::<F, EF4>(&point.0, &mut expected_weights, weight);
         assert_eq!(prover.weights.evals(), &expected_weights);
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use rayon::prelude::*;
 pub(crate) fn eval_eq<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [EF], scalar: EF) {
     // Number of threads to spawn.
     // Long term this should be a modifiable parameter.
-    // I've chosen 32 here as my machine has 20 logical cores. PLausibly we might want to hard code this
+    // I've chosen 32 here as my machine has 20 logical cores. Plausibly we might want to hard code this
     // to be a little larger than this.
     #[cfg(feature = "parallel")]
     const LOG_NUM_THREADS: usize = 5;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -83,36 +83,38 @@ pub(crate) fn eval_eq<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [E
             out[7] += s111;
         }
         _ => {
-            // let (&x, tail) = eval.split_first().unwrap();
-
-            // // Divide the output buffer into two halves: one for `X_i = 0` and one for `X_i = 1`
-            // let (low, high) = out.split_at_mut(out.len() / 2);
-
-            // // Compute weight updates for the two branches:
-            // // - `s0` corresponds to the case when `X_i = 0`
-            // // - `s1` corresponds to the case when `X_i = 1`
-            // //
-            // // Mathematically, this follows the recurrence:
-            // // ```text
-            // // eq_{X1, ..., Xn}(X) = (1 - X_1) * eq_{X2, ..., Xn}(X) + X_1 * eq_{X2, ..., Xn}(X)
-            // // ```
-            // let s1 = scalar * x; // Contribution when `X_i = 1`
-            // let s0 = scalar - s1; // Contribution when `X_i = 0`
-
-            // // Use parallel execution if the number of remaining variables is large.
-            // #[cfg(feature = "parallel")]
-            // {
-            //     const PARALLEL_THRESHOLD: usize = 10;
-            //     if tail.len() > PARALLEL_THRESHOLD {
-            //         rayon::join(|| eval_eq(tail, low, s0), || eval_eq(tail, high, s1));
-            //         return;
-            //     }
-            // }
-            // // Default sequential execution
-            // eval_eq(tail, low, s0);
-            // eval_eq(tail, high, s1);
             const LOG_NUM_THREADS: usize = 5;
             const NUM_THREADS: usize = 1 << LOG_NUM_THREADS;
+
+            if eval.len() < 10 + LOG_NUM_THREADS {
+                // If the number of variables is small, use a sequential approach
+                eval_eq_no_par(eval, out, scalar);
+                return;
+            }
+
+            // let mut parallel_buffer = [EF::ZERO; NUM_THREADS];
+            // parallel_buffer[0] = scalar;
+
+            // for (ind, entry) in eval[..LOG_NUM_THREADS].iter().rev().enumerate() {
+            //     let stride = 1 << ind;
+
+            //     for index in 0..stride {
+            //         let val = parallel_buffer[index];
+            //         let scaled_val = val * *entry;
+            //         let new_val = val - scaled_val;
+
+            //         parallel_buffer[index] = new_val;
+            //         parallel_buffer[index + stride] = scaled_val;
+            //     }
+            // }
+
+            // let chunk_size = out.len() / NUM_THREADS;
+
+            // out.par_chunks_exact_mut(chunk_size)
+            //     .zip(parallel_buffer.par_iter())
+            //     .for_each(|(out_chunk, buffer_val)| {
+            //         eval_eq_no_par(&eval[LOG_NUM_THREADS..], out_chunk, *buffer_val);
+            //     });
 
             let packing_width = F::Packing::WIDTH;
             assert!(packing_width > 1);
@@ -140,44 +142,286 @@ pub(crate) fn eval_eq<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [E
             out.par_chunks_exact_mut(out_chunk_size)
                 .zip(parallel_buffer.par_iter())
                 .for_each(|(out_chunk, buffer_val)| {
-                    let mut chunk_buffer = EF::ExtensionPacking::zero_vec(
-                        1 << (eval.len() - LOG_NUM_THREADS - log_packing_width),
+                    eval_eq_packed(
+                        &eval[LOG_NUM_THREADS..(eval.len() - log_packing_width)],
+                        out_chunk,
+                        *buffer_val,
                     );
-                    chunk_buffer[0] = *buffer_val;
-                    info_span!(
-                        "Build buffer",
-                        size = eval.len() - LOG_NUM_THREADS - log_packing_width
-                    )
-                    .in_scope(|| {
-                        for (ind, entry) in eval[LOG_NUM_THREADS..(eval.len() - log_packing_width)]
-                            .iter()
-                            .rev()
-                            .enumerate()
-                        {
-                            let stride = 1 << ind;
+                    // let mut chunk_buffer = EF::ExtensionPacking::zero_vec(
+                    //     1 << (eval.len() - LOG_NUM_THREADS - log_packing_width),
+                    // );
+                    // info_span!("eval_eq_packed", size = eval.len() - LOG_NUM_THREADS).in_scope(
+                    //     || {
+                    //         chunk_buffer[0] = *buffer_val;
 
-                            for index in 0..stride {
-                                let val = chunk_buffer[index];
-                                let scaled_val = val * *entry;
-                                let new_val = val - scaled_val;
+                    //         for (ind, entry) in eval
+                    //             [LOG_NUM_THREADS..(eval.len() - log_packing_width)]
+                    //             .iter()
+                    //             .rev()
+                    //             .enumerate()
+                    //         {
+                    //             let stride = 1 << ind;
 
-                                chunk_buffer[index] = new_val;
-                                chunk_buffer[index + stride] = scaled_val;
-                            }
-                        }
-                    });
-                    info_span!(
-                        "Update output vector",
-                        size = eval.len() - LOG_NUM_THREADS - log_packing_width
-                    )
-                    .in_scope(|| {
-                        EF::ExtensionPacking::to_ext_iter(chunk_buffer)
-                            .zip(out_chunk.iter_mut())
-                            .for_each(|(packed_val, out_val)| {
-                                *out_val += packed_val;
-                            });
-                    });
+                    //             for index in 0..stride {
+                    //                 let val = chunk_buffer[index];
+                    //                 let scaled_val = val * *entry;
+                    //                 let new_val = val - scaled_val;
+
+                    //                 chunk_buffer[index] = new_val;
+                    //                 chunk_buffer[index + stride] = scaled_val;
+                    //             }
+                    //         }
+                    //     },
+                    // );
+
+                    // info_span!("update", size = eval.len() - LOG_NUM_THREADS).in_scope(|| {
+                    //     EF::ExtensionPacking::to_ext_iter(chunk_buffer)
+                    //         .zip(out_chunk.iter_mut())
+                    //         .for_each(|(packed_val, out_val)| {
+                    //             *out_val += packed_val;
+                    //         });
+                    // });
                 });
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn eval_eq_no_par<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [EF], scalar: EF) {
+    // Ensure that the output buffer size is correct:
+    // It should be of size `2^n`, where `n` is the number of variables.
+    debug_assert_eq!(out.len(), 1 << eval.len());
+
+    match eval.len() {
+        0 => {
+            out[0] += scalar;
+        }
+        1 => {
+            // Manually unroll for single variable case
+            let x = eval[0];
+            let s1 = scalar * x;
+            let s0 = scalar - s1;
+
+            out[0] += s0;
+            out[1] += s1;
+        }
+        2 => {
+            // Manually unroll for two variables case
+            let x0 = eval[0];
+            let x1 = eval[1];
+
+            let s1 = scalar * x0;
+            let s0 = scalar - s1;
+
+            let s01 = s0 * x1;
+            let s00 = s0 - s01;
+            let s11 = s1 * x1;
+            let s10 = s1 - s11;
+
+            out[0] += s00;
+            out[1] += s01;
+            out[2] += s10;
+            out[3] += s11;
+        }
+        3 => {
+            // Three variables case (manually unrolled)
+            let x0 = eval[0];
+            let x1 = eval[1];
+            let x2 = eval[2];
+
+            let s1 = scalar * x0;
+            let s0 = scalar - s1;
+
+            let s01 = s0 * x1;
+            let s00 = s0 - s01;
+            let s11 = s1 * x1;
+            let s10 = s1 - s11;
+
+            let s001 = s00 * x2;
+            let s000 = s00 - s001;
+            let s011 = s01 * x2;
+            let s010 = s01 - s011;
+            let s101 = s10 * x2;
+            let s100 = s10 - s101;
+            let s111 = s11 * x2;
+            let s110 = s11 - s111;
+
+            out[0] += s000;
+            out[1] += s001;
+            out[2] += s010;
+            out[3] += s011;
+            out[4] += s100;
+            out[5] += s101;
+            out[6] += s110;
+            out[7] += s111;
+        }
+        _ => {
+            let remaining_eval = eval;
+            let remaining_out = out;
+            let current_scalar = scalar;
+
+            // loop {
+            let (&x, tail) = remaining_eval.split_first().unwrap();
+
+            // Divide the output buffer into two halves: one for `X_i = 0` and one for `X_i = 1`
+            let (low, high) = remaining_out.split_at_mut(remaining_out.len() / 2);
+
+            // Compute weight updates for the two branches:
+            // - `s0` corresponds to the case when `X_i = 0`
+            // - `s1` corresponds to the case when `X_i = 1`
+            //
+            // Mathematically, this follows the recurrence:
+            // ```text
+            // eq_{X1, ..., Xn}(X) = (1 - X_1) * eq_{X2, ..., Xn}(X) + X_1 * eq_{X2, ..., Xn}(X)
+            // ```
+            let s1 = current_scalar * x; // Contribution when `X_i = 1`
+            let s0 = current_scalar - s1; // Contribution when `X_i = 0`
+
+            // if tail.len() <= 3 {
+            // Use existing optimized base cases
+            eval_eq_no_par(tail, low, s0);
+            eval_eq_no_par(tail, high, s1);
+            // break;
+            // }
+
+            // Recurse on one branch, continue loop with the other
+            // eval_eq_no_par(tail, high, s1);
+
+            // // Continue with low branch (tail call optimization)
+            // remaining_eval = tail;
+            // remaining_out = low;
+            // current_scalar = s0;
+
+            // // Default sequential execution
+            // eval_eq_no_par(tail, low, s0);
+            // eval_eq_no_par(tail, high, s1);
+            // }
+
+            // let mut buffer = EF::zero_vec(1 << eval.len());
+            // buffer[0] = scalar;
+
+            // for (ind, entry) in eval.iter().rev().enumerate() {
+            //     let stride = 1 << ind;
+
+            //     for index in 0..stride {
+            //         let val = buffer[index];
+            //         let scaled_val = val * *entry;
+            //         let new_val = val - scaled_val;
+
+            //         buffer[index] = new_val;
+            //         buffer[index + stride] = scaled_val;
+            //     }
+            // }
+
+            // out.iter_mut()
+            //     .zip(buffer.iter())
+            //     .for_each(|(out_val, buffer_val)| {
+            //         *out_val += *buffer_val;
+            //     });
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn eval_eq_packed<F: Field, EF: ExtensionField<F>>(
+    eval: &[EF],
+    out: &mut [EF],
+    scalar: EF::ExtensionPacking,
+) {
+    // Ensure that the output buffer size is correct:
+    // It should be of size `2^n`, where `n` is the number of variables.
+    let width = F::Packing::WIDTH;
+    debug_assert_eq!(out.len(), width << eval.len());
+
+    match eval.len() {
+        0 => {
+            EF::ExtensionPacking::to_ext_iter([scalar])
+                .zip(out.iter_mut())
+                .for_each(|(scalar, out)| {
+                    *out += scalar;
+                });
+        }
+        1 => {
+            // Manually unroll for single variable case
+            let x = eval[0];
+            let s1 = scalar * x;
+            let s0 = scalar - s1;
+
+            EF::ExtensionPacking::to_ext_iter([s0, s1])
+                .zip(out.iter_mut())
+                .for_each(|(scalar, out)| {
+                    *out += scalar;
+                });
+        }
+        2 => {
+            // Manually unroll for two variables case
+            let x0 = eval[0];
+            let x1 = eval[1];
+
+            let s1 = scalar * x0;
+            let s0 = scalar - s1;
+
+            let s01 = s0 * x1;
+            let s00 = s0 - s01;
+            let s11 = s1 * x1;
+            let s10 = s1 - s11;
+
+            EF::ExtensionPacking::to_ext_iter([s00, s01, s10, s11])
+                .zip(out.iter_mut())
+                .for_each(|(scalar, out)| {
+                    *out += scalar;
+                });
+        }
+        3 => {
+            // Three variables case (manually unrolled)
+            let x0 = eval[0];
+            let x1 = eval[1];
+            let x2 = eval[2];
+
+            let s1 = scalar * x0;
+            let s0 = scalar - s1;
+
+            let s01 = s0 * x1;
+            let s00 = s0 - s01;
+            let s11 = s1 * x1;
+            let s10 = s1 - s11;
+
+            let s001 = s00 * x2;
+            let s000 = s00 - s001;
+            let s011 = s01 * x2;
+            let s010 = s01 - s011;
+            let s101 = s10 * x2;
+            let s100 = s10 - s101;
+            let s111 = s11 * x2;
+            let s110 = s11 - s111;
+
+            EF::ExtensionPacking::to_ext_iter([s000, s001, s010, s011, s100, s101, s110, s111])
+                .zip(out.iter_mut())
+                .for_each(|(scalar, out)| {
+                    *out += scalar;
+                });
+        }
+        _ => {
+            let (&x, tail) = eval.split_first().unwrap();
+
+            // Divide the output buffer into two halves: one for `X_i = 0` and one for `X_i = 1`
+            let (low, high) = out.split_at_mut(out.len() / 2);
+
+            // Compute weight updates for the two branches:
+            // - `s0` corresponds to the case when `X_i = 0`
+            // - `s1` corresponds to the case when `X_i = 1`
+            //
+            // Mathematically, this follows the recurrence:
+            // ```text
+            // eq_{X1, ..., Xn}(X) = (1 - X_1) * eq_{X2, ..., Xn}(X) + X_1 * eq_{X2, ..., Xn}(X)
+            // ```
+            let s1 = scalar * x; // Contribution when `X_i = 1`
+            let s0 = scalar - s1; // Contribution when `X_i = 0`
+
+            // if tail.len() <= 3 {
+            // Use existing optimized base cases
+            eval_eq_packed(tail, low, s0);
+            eval_eq_packed(tail, high, s1);
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use p3_field::{
     Algebra, ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
 };
 use p3_util::log2_strict_usize;
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 /// Computes the equality polynomial evaluations efficiently.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,6 @@ use tracing::instrument;
 /// ```
 ///
 /// where `z_i` are the constraint points.
-#[instrument(skip_all, fields(size = eval.len()))]
 #[inline]
 pub(crate) fn eval_eq<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [EF], scalar: EF) {
     // Number of threads to spawn.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -246,7 +246,7 @@ fn eval_eq_basic<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [EF], s
 /// eq(X) = scalar[j] * ∏ (1 - X_i + 2X_i z_i)
 /// ```
 ///
-/// for a collection of `i` at the same time. Here `scalar[j]` should be though of as evaluations of an equality
+/// for a collection of `i` at the same time. Here `scalar[j]` should be thought of as evaluations of an equality
 /// polynomial over different variables so `eq(X)` ends up being the evaluation of the equality polynomial over
 /// the combined set of variables.
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,7 @@
-use p3_field::Field;
+use p3_field::{ExtensionField, Field, PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
+use p3_util::log2_strict_usize;
+use rayon::prelude::*;
+use tracing::info_span;
 
 /// Computes the equality polynomial evaluations efficiently.
 ///
@@ -10,7 +13,8 @@ use p3_field::Field;
 /// ```
 ///
 /// where `z_i` are the constraint points.
-pub(crate) fn eval_eq<F: Field>(eval: &[F], out: &mut [F], scalar: F) {
+#[allow(clippy::too_many_lines)]
+pub(crate) fn eval_eq<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [EF], scalar: EF) {
     // Ensure that the output buffer size is correct:
     // It should be of size `2^n`, where `n` is the number of variables.
     debug_assert_eq!(out.len(), 1 << eval.len());
@@ -79,36 +83,134 @@ pub(crate) fn eval_eq<F: Field>(eval: &[F], out: &mut [F], scalar: F) {
             out[7] += s111;
         }
         _ => {
-            let (&x, tail) = eval.split_first().unwrap();
+            // let (&x, tail) = eval.split_first().unwrap();
 
-            // Divide the output buffer into two halves: one for `X_i = 0` and one for `X_i = 1`
-            let (low, high) = out.split_at_mut(out.len() / 2);
+            // // Divide the output buffer into two halves: one for `X_i = 0` and one for `X_i = 1`
+            // let (low, high) = out.split_at_mut(out.len() / 2);
 
-            // Compute weight updates for the two branches:
-            // - `s0` corresponds to the case when `X_i = 0`
-            // - `s1` corresponds to the case when `X_i = 1`
-            //
-            // Mathematically, this follows the recurrence:
-            // ```text
-            // eq_{X1, ..., Xn}(X) = (1 - X_1) * eq_{X2, ..., Xn}(X) + X_1 * eq_{X2, ..., Xn}(X)
-            // ```
-            let s1 = scalar * x; // Contribution when `X_i = 1`
-            let s0 = scalar - s1; // Contribution when `X_i = 0`
+            // // Compute weight updates for the two branches:
+            // // - `s0` corresponds to the case when `X_i = 0`
+            // // - `s1` corresponds to the case when `X_i = 1`
+            // //
+            // // Mathematically, this follows the recurrence:
+            // // ```text
+            // // eq_{X1, ..., Xn}(X) = (1 - X_1) * eq_{X2, ..., Xn}(X) + X_1 * eq_{X2, ..., Xn}(X)
+            // // ```
+            // let s1 = scalar * x; // Contribution when `X_i = 1`
+            // let s0 = scalar - s1; // Contribution when `X_i = 0`
 
-            // Use parallel execution if the number of remaining variables is large.
-            #[cfg(feature = "parallel")]
-            {
-                const PARALLEL_THRESHOLD: usize = 10;
-                if tail.len() > PARALLEL_THRESHOLD {
-                    rayon::join(|| eval_eq(tail, low, s0), || eval_eq(tail, high, s1));
-                    return;
+            // // Use parallel execution if the number of remaining variables is large.
+            // #[cfg(feature = "parallel")]
+            // {
+            //     const PARALLEL_THRESHOLD: usize = 10;
+            //     if tail.len() > PARALLEL_THRESHOLD {
+            //         rayon::join(|| eval_eq(tail, low, s0), || eval_eq(tail, high, s1));
+            //         return;
+            //     }
+            // }
+            // // Default sequential execution
+            // eval_eq(tail, low, s0);
+            // eval_eq(tail, high, s1);
+            const LOG_NUM_THREADS: usize = 5;
+            const NUM_THREADS: usize = 1 << LOG_NUM_THREADS;
+
+            let packing_width = F::Packing::WIDTH;
+            assert!(packing_width > 1);
+            let log_packing_width = log2_strict_usize(packing_width);
+            let eval_len_min_packing = eval.len() - log_packing_width;
+            let mut parallel_buffer = EF::ExtensionPacking::zero_vec(NUM_THREADS);
+
+            let out_chunk_size = out.len() / NUM_THREADS;
+
+            parallel_buffer[0] = packed_eq_poly(&eval[eval_len_min_packing..], scalar);
+
+            for (ind, entry) in eval[..LOG_NUM_THREADS].iter().rev().enumerate() {
+                let stride = 1 << ind;
+
+                for index in 0..stride {
+                    let val = parallel_buffer[index];
+                    let scaled_val = val * *entry;
+                    let new_val = val - scaled_val;
+
+                    parallel_buffer[index] = new_val;
+                    parallel_buffer[index + stride] = scaled_val;
                 }
             }
-            // Default sequential execution
-            eval_eq(tail, low, s0);
-            eval_eq(tail, high, s1);
+
+            out.par_chunks_exact_mut(out_chunk_size)
+                .zip(parallel_buffer.par_iter())
+                .for_each(|(out_chunk, buffer_val)| {
+                    let mut chunk_buffer = EF::ExtensionPacking::zero_vec(
+                        1 << (eval.len() - LOG_NUM_THREADS - log_packing_width),
+                    );
+                    chunk_buffer[0] = *buffer_val;
+                    info_span!(
+                        "Build buffer",
+                        size = eval.len() - LOG_NUM_THREADS - log_packing_width
+                    )
+                    .in_scope(|| {
+                        for (ind, entry) in eval[LOG_NUM_THREADS..(eval.len() - log_packing_width)]
+                            .iter()
+                            .rev()
+                            .enumerate()
+                        {
+                            let stride = 1 << ind;
+
+                            for index in 0..stride {
+                                let val = chunk_buffer[index];
+                                let scaled_val = val * *entry;
+                                let new_val = val - scaled_val;
+
+                                chunk_buffer[index] = new_val;
+                                chunk_buffer[index + stride] = scaled_val;
+                            }
+                        }
+                    });
+                    info_span!(
+                        "Update output vector",
+                        size = eval.len() - LOG_NUM_THREADS - log_packing_width
+                    )
+                    .in_scope(|| {
+                        EF::ExtensionPacking::to_ext_iter(chunk_buffer)
+                            .zip(out_chunk.iter_mut())
+                            .for_each(|(packed_val, out_val)| {
+                                *out_val += packed_val;
+                            });
+                    });
+                });
         }
     }
+}
+
+/// Compute the inner most layers of the equality polynomial and pack the result
+/// into a `PackedFieldExtension`.
+fn packed_eq_poly<F: Field, EF: ExtensionField<F>>(
+    eval: &[EF],
+    scalar: EF,
+) -> EF::ExtensionPacking {
+    debug_assert_eq!(F::Packing::WIDTH, eval.len());
+
+    let mut buffer = EF::zero_vec(1 << eval.len());
+    buffer[0] = scalar;
+
+    for (ind, entry) in eval.iter().rev().enumerate() {
+        // After round 1 buffer should look like:
+        // [(1 - xn)*scalar, xn*scalar, 0, 0, ...]
+        // After round 2 buffer should look like:
+        // [(1 - xn)*(1 - x_{n-1})*scalar, xn*(1 - x_{n-1})*scalar,
+        //      (1 - xn)*x_{n-1}*scalar, xn*x_{n-1}*scalar, 0, 0, ...]
+        let stride = 1 << ind;
+        for index in 0..stride {
+            let val = buffer[index];
+            let scaled_val = val * *entry;
+            let new_val = val - scaled_val;
+
+            buffer[index] = new_val;
+            buffer[index + stride] = scaled_val;
+        }
+    }
+
+    EF::ExtensionPacking::from_ext_slice(&buffer)
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,6 @@ use p3_field::{
 };
 use p3_util::log2_strict_usize;
 use rayon::prelude::*;
-use tracing::instrument;
 
 /// Computes the equality polynomial evaluations efficiently.
 ///
@@ -29,7 +28,7 @@ pub(crate) fn eval_eq<F: Field, EF: ExtensionField<F>>(eval: &[EF], out: &mut [E
     const NUM_THREADS: usize = 1 << LOG_NUM_THREADS;
 
     // It's possible for this to be called with F = EF (Despite F actually being an extension field).
-    // This check ensures this is not the case.
+    // This check ensures this is not the case unless F is a prime field with non-trivial packing.
     let packing_width = F::Packing::WIDTH;
     debug_assert!(packing_width > 1);
 

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -255,7 +255,14 @@ where
                 coeffs
             });
             // Do DFT on only interleaved polys to be folded.
-            dft.dft_algebra_batch(RowMajorMatrix::new(coeffs, 1 << folding_factor_next))
+            info_span!(
+                "dft",
+                height = coeffs.len() >> folding_factor_next,
+                width = 1 << folding_factor_next
+            )
+            .in_scope(|| {
+                dft.dft_algebra_batch(RowMajorMatrix::new(coeffs, 1 << folding_factor_next))
+            })
         });
 
         let mmcs = MerkleTreeMmcs::new(self.merkle_hash.clone(), self.merkle_compress.clone());

--- a/src/whir/statement/weights.rs
+++ b/src/whir/statement/weights.rs
@@ -1,7 +1,7 @@
 use p3_field::{ExtensionField, Field};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use tracing::{info_span, instrument};
+use tracing::instrument;
 
 use crate::{
     poly::{coeffs::CoefficientList, evals::EvaluationsList, multilinear::MultilinearPoint},


### PR DESCRIPTION
Updated Eval Eq to make use of Packings.

Unfortunately, the data on this seems to be a little mixed. For `BabyBear`, with extension field of degree 5, this gives around a `30-40%` speed up.

But for Goldilocks, with the extension field of degree `2`, its actually a little slower `10-15%` or so. This is probably due to the extra data fiddling involved and also the fact that `PackedGoldilocksAVX2` just isn't much of an improvement over the base Goldilocks. (Addition is a little faster but multiplication is mostly unchanged). Overall a little frustrating.

I've got a couple of idea's for how to speed this up a little more but it involves changes to Plonky3 so I'll have to test/merge them first over there.

Let me know if you'd rather not merge this for now.