### PR TITLE
custom initial Reed Solomon reduction

### DIFF
--- a/benches/whir.rs
+++ b/benches/whir.rs
@@ -10,6 +10,7 @@ fn benchmark_whir(c: &mut Criterion) {
     let num_points = 2;
     let soundness_type = SecurityAssumption::UniqueDecoding;
     let pow_bits = 10;
+    let rs_domain_initial_reduction_factor = 1;
 
     for num_variables in polynomial_sizes {
         c.bench_function(&format!("whir_end_to_end_size {num_variables}"), |b| {
@@ -20,6 +21,7 @@ fn benchmark_whir(c: &mut Criterion) {
                     num_points,
                     soundness_type,
                     pow_bits,
+                    rs_domain_initial_reduction_factor,
                 );
             });
         });

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -54,6 +54,9 @@ struct Args {
 
     #[arg(long = "sec", default_value = "CapacityBound")]
     soundness_type: SecurityAssumption,
+
+    #[arg(long = "initial-rs-reduction", default_value = "1")]
+    rs_domain_initial_reduction_factor: usize,
 }
 
 fn main() {
@@ -89,6 +92,7 @@ fn main() {
     let byte_hash = ByteHash {};
     let merkle_hash = FieldHash::new(byte_hash);
     let merkle_compress = MyCompress::new(byte_hash);
+    let rs_domain_initial_reduction_factor = args.rs_domain_initial_reduction_factor;
 
     let num_coeffs = 1 << num_variables;
 
@@ -104,6 +108,7 @@ fn main() {
         merkle_compress,
         soundness_type,
         starting_log_inv_rate: starting_rate,
+        rs_domain_initial_reduction_factor,
     };
 
     let params = WhirConfig::<EF, F, FieldHash, MyCompress, Blake3PoW>::new(mv_params, whir_params);

--- a/src/fiat_shamir/domain_separator.rs
+++ b/src/fiat_shamir/domain_separator.rs
@@ -266,7 +266,7 @@ where
                 params.folding_factor.at_round(round + 1),
                 r.folding_pow_bits,
             );
-            domain_size >>= 1;
+            domain_size >>= params.rs_reduction_factor(round);
         }
 
         let folded_domain_size = domain_size

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -181,6 +181,12 @@ pub struct ProtocolParameters<H, C> {
     pub initial_statement: bool,
     /// The logarithmic inverse rate for sampling.
     pub starting_log_inv_rate: usize,
+    /// The value v such that that the size of the Reed Solomon domain on which
+    /// our polynomial is evaluated gets divided by `2^v` at the first round.
+    /// RS domain size at commitment = 2^(num_variables + starting_log_inv_rate)
+    /// RS domain size after the first round = 2^(num_variables + starting_log_inv_rate - v)
+    /// The default value is 1 (halving the domain size, which is the behavior of the consecutive rounds).
+    pub rs_domain_initial_reduction_factor: usize,
     /// The folding factor strategy.
     pub folding_factor: FoldingFactor,
     /// The type of soundness guarantee.

--- a/src/whir/committer/reader.rs
+++ b/src/whir/committer/reader.rs
@@ -215,6 +215,7 @@ mod tests {
             initial_statement: true,
             security_level: 100,
             pow_bits: 10,
+            rs_domain_initial_reduction_factor: 1,
             folding_factor: FoldingFactor::ConstantFromSecondRound(4, 4),
             merkle_hash: field_hash,
             merkle_compress: compress,

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -169,6 +169,7 @@ mod tests {
             initial_statement: true,
             security_level,
             pow_bits,
+            rs_domain_initial_reduction_factor: 1,
             folding_factor: FoldingFactor::ConstantFromSecondRound(
                 first_round_folding_factor,
                 folding_factor,
@@ -254,6 +255,7 @@ mod tests {
             initial_statement: true,
             security_level,
             pow_bits,
+            rs_domain_initial_reduction_factor: 1,
             folding_factor: FoldingFactor::ConstantFromSecondRound(
                 first_round_folding_factor,
                 folding_factor,
@@ -301,6 +303,7 @@ mod tests {
             initial_statement: true,
             security_level,
             pow_bits,
+            rs_domain_initial_reduction_factor: 1,
             folding_factor: FoldingFactor::ConstantFromSecondRound(
                 first_round_folding_factor,
                 folding_factor,

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -48,6 +48,7 @@ pub fn make_whir_things(
     num_points: usize,
     soundness_type: SecurityAssumption,
     pow_bits: usize,
+    rs_domain_initial_reduction_factor: usize,
 ) {
     // Number of coefficients = 2^num_variables
     let num_coeffs = 1 << num_variables;
@@ -65,6 +66,7 @@ pub fn make_whir_things(
         initial_statement: true,
         security_level: 32,
         pow_bits,
+        rs_domain_initial_reduction_factor,
         folding_factor,
         merkle_hash,
         merkle_compress,
@@ -174,20 +176,27 @@ mod tests {
         ];
         let num_points = [0, 1, 2];
         let pow_bits = [0, 5, 10];
+        let rs_domain_initial_reduction_factors = 1..=3;
 
-        for folding_factor in folding_factors {
-            let num_variables = folding_factor.at_round(0)..=3 * folding_factor.at_round(0);
-            for num_variable in num_variables {
-                for num_points in num_points {
-                    for soundness_type in soundness_type {
-                        for pow_bits in pow_bits {
-                            make_whir_things(
-                                num_variable,
-                                folding_factor,
-                                num_points,
-                                soundness_type,
-                                pow_bits,
-                            );
+        for rs_domain_initial_reduction_factor in rs_domain_initial_reduction_factors {
+            for folding_factor in folding_factors {
+                if folding_factor.at_round(0) < rs_domain_initial_reduction_factor {
+                    continue;
+                }
+                let num_variables = folding_factor.at_round(0)..=3 * folding_factor.at_round(0);
+                for num_variable in num_variables {
+                    for num_points in num_points {
+                        for soundness_type in soundness_type {
+                            for pow_bits in pow_bits {
+                                make_whir_things(
+                                    num_variable,
+                                    folding_factor,
+                                    num_points,
+                                    soundness_type,
+                                    pow_bits,
+                                    rs_domain_initial_reduction_factor,
+                                );
+                            }
                         }
                     }
                 }

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -246,7 +246,8 @@ where
         let folding_factor_next = self.folding_factor.at_round(round_index + 1);
 
         // Compute polynomial evaluations and build Merkle tree
-        let new_domain = round_state.domain.scale(2);
+        let domain_reduction = 1 << self.rs_reduction_factor(round_index);
+        let new_domain = round_state.domain.scale(domain_reduction);
         let folded_matrix = info_span!("fold matrix").in_scope(|| {
             let coeffs = info_span!("copy_across_coeffs").in_scope(|| {
                 let mut coeffs = EF::zero_vec(new_domain.size());

--- a/src/whir/prover/round.rs
+++ b/src/whir/prover/round.rs
@@ -241,6 +241,7 @@ mod tests {
             initial_statement,
             security_level: 80,
             pow_bits,
+            rs_domain_initial_reduction_factor: 1,
             folding_factor: FoldingFactor::Constant(folding_factor),
             merkle_hash: FieldHash::new(ByteHash {}),
             merkle_compress: MyCompress::new(ByteHash {}),

--- a/src/whir/verifier/sumcheck.rs
+++ b/src/whir/verifier/sumcheck.rs
@@ -176,6 +176,7 @@ mod tests {
             initial_statement: true,
             security_level: 32,
             pow_bits: 0,
+            rs_domain_initial_reduction_factor: 1,
             folding_factor: FoldingFactor::Constant(2),
             merkle_hash,
             merkle_compress,


### PR DESCRIPTION
This significantly improves perf when the committed polynomial is on a small field, typically KoalaBear.
Doubles the perf on Whirlaway. Before this commit: 25K poseidon2/s. After : 50K poseidon2/s
