### PR TITLE
parallel_copy

### DIFF
--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -14,6 +14,7 @@ use super::Witness;
 use crate::{
     fiat_shamir::{errors::ProofResult, prover::ProverState, unit::Unit},
     poly::{coeffs::CoefficientList, evals::EvaluationsList},
+    utils::parallel_copy,
     whir::{committer::DenseMatrix, parameters::WhirConfig, utils::sample_ood_points},
 };
 
@@ -77,7 +78,7 @@ where
         // Pad coefficients with zeros to match the domain size
         let coeffs = info_span!("copy_across_coeffs").in_scope(|| {
             let mut coeffs = F::zero_vec(expanded_size);
-            coeffs[..initial_size].copy_from_slice(pol_coeffs.coeffs());
+            parallel_copy(pol_coeffs.coeffs(), &mut coeffs[..initial_size]);
             coeffs
         });
 

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         multilinear::MultilinearPoint,
     },
     sumcheck::sumcheck_single::SumcheckSingle,
+    utils::parallel_copy,
     whir::{
         parameters::RoundConfig,
         statement::weights::Weights,
@@ -252,8 +253,10 @@ where
         let folded_matrix = info_span!("fold matrix").in_scope(|| {
             let coeffs = info_span!("copy_across_coeffs").in_scope(|| {
                 let mut coeffs = EF::zero_vec(new_domain.size());
-                coeffs[..folded_evaluations.num_evals()]
-                    .copy_from_slice(folded_coefficients.coeffs());
+                parallel_copy(
+                    folded_coefficients.coeffs(),
+                    &mut coeffs[..folded_evaluations.num_evals()],
+                );
                 coeffs
             });
             // Do DFT on only interleaved polys to be folded.


### PR DESCRIPTION
To get an idea an idea of the speedup:

```
RUSTFLAGS='-C target-cpu=native' cargo test --release --package whir-p3 --lib -- utils::tests::test_parallel_copy --exact --show-output
```

Running `main.rs`, and analyzing the time spent on the 5 invocations of `copy_across_coeffs`, on my machine:
| Before    | After |
| -------- | ------- |
| 42.7ms  | 9.84ms    |
| 7.59ms | 2.25ms     |
| 424µs    | 181µs    |
| 84.0µs    | 75.9µs    |
| 736µs    | 743µs    |


