### PR TITLE
parallel_clone for EvaluationsList

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -428,23 +428,36 @@ fn packed_eq_poly<F: Field, EF: ExtensionField<F>>(
     EF::ExtensionPacking::from_ext_slice(&buffer)
 }
 
-pub fn parallel_copy<A: Copy + Send + Sync>(src: &[A], dst: &mut [A]) {
+pub fn parallel_clone<A: Clone + Send + Sync>(src: &[A], dst: &mut [A]) {
     #[cfg(feature = "parallel")]
     if src.len() < 1 << 15 {
         // sequential copy
-        dst.copy_from_slice(src);
+        dst.clone_from_slice(src);
     } else {
         assert_eq!(src.len(), dst.len());
         let chunk_size = src.len() / rayon::current_num_threads().max(1);
         dst.par_chunks_mut(chunk_size)
             .zip(src.par_chunks(chunk_size))
             .for_each(|(d, s)| {
-                d.copy_from_slice(s);
+                d.clone_from_slice(s);
             });
     }
 
     #[cfg(not(feature = "parallel"))]
-    dst.copy_from_slice(src);
+    dst.clone_from_slice(src);
+}
+
+/// Returns a vector of uninitialized elements of type `A` with the specified length.
+/// # Safety
+/// Entries should be overwritten before use.
+#[must_use]
+pub unsafe fn uninitialized_vec<A>(len: usize) -> Vec<A> {
+    #[allow(clippy::uninit_vec)]
+    unsafe {
+        let mut vec = Vec::with_capacity(len);
+        vec.set_len(len);
+        vec
+    }
 }
 
 #[cfg(test)]
@@ -459,7 +472,7 @@ mod tests {
     type EF4 = BinomialExtensionField<F, 4>;
 
     #[test]
-    fn test_parallel_copy() {
+    fn test_parallel_clone() {
         let src = (0..(1 << 25) + 7).map(F::from_u64).collect::<Vec<_>>();
         let mut dst_seq = F::zero_vec(src.len());
         let time = std::time::Instant::now();
@@ -467,7 +480,7 @@ mod tests {
         println!("Sequential copy took: {:?}", time.elapsed());
         let mut dst_parallel = F::zero_vec(src.len());
         let time = std::time::Instant::now();
-        parallel_copy(&src, &mut dst_parallel);
+        parallel_clone(&src, &mut dst_parallel);
         println!("Parallel copy took: {:?}", time.elapsed());
         assert_eq!(dst_seq, dst_parallel);
     }

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -14,7 +14,7 @@ use super::Witness;
 use crate::{
     fiat_shamir::{errors::ProofResult, prover::ProverState, unit::Unit},
     poly::{coeffs::CoefficientList, evals::EvaluationsList},
-    utils::parallel_copy,
+    utils::parallel_clone,
     whir::{committer::DenseMatrix, parameters::WhirConfig, utils::sample_ood_points},
 };
 
@@ -69,7 +69,7 @@ where
         W: Eq + Packable,
     {
         // convert evaluations -> coefficients form
-        let pol_coeffs: CoefficientList<F> = polynomial.clone().to_coefficients();
+        let pol_coeffs: CoefficientList<F> = polynomial.parallel_clone().to_coefficients();
 
         // Compute expansion factor based on the domain size and polynomial length.
         let initial_size = polynomial.num_evals();
@@ -78,7 +78,7 @@ where
         // Pad coefficients with zeros to match the domain size
         let coeffs = info_span!("copy_across_coeffs").in_scope(|| {
             let mut coeffs = F::zero_vec(expanded_size);
-            parallel_copy(pol_coeffs.coeffs(), &mut coeffs[..initial_size]);
+            parallel_clone(pol_coeffs.coeffs(), &mut coeffs[..initial_size]);
             coeffs
         });
 

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         multilinear::MultilinearPoint,
     },
     sumcheck::sumcheck_single::SumcheckSingle,
-    utils::parallel_copy,
+    utils::parallel_clone,
     whir::{
         parameters::RoundConfig,
         statement::weights::Weights,
@@ -215,7 +215,7 @@ where
                 EvaluationStorage::Base(_) => {
                     panic!("After a first round, the evaluations must be in the extension field")
                 }
-                EvaluationStorage::Extension(f) => f.clone(),
+                EvaluationStorage::Extension(f) => f.parallel_clone(),
             }
         } else {
             round_state
@@ -253,7 +253,7 @@ where
         let folded_matrix = info_span!("fold matrix").in_scope(|| {
             let coeffs = info_span!("copy_across_coeffs").in_scope(|| {
                 let mut coeffs = EF::zero_vec(new_domain.size());
-                parallel_copy(
+                parallel_clone(
                     folded_coefficients.coeffs(),
                     &mut coeffs[..folded_evaluations.num_evals()],
                 );
@@ -385,7 +385,7 @@ where
                 }
 
                 SumcheckSingle::from_extension_evals(
-                    folded_evaluations.clone(),
+                    folded_evaluations.parallel_clone(),
                     &statement,
                     combination_randomness[1],
                 )
@@ -500,7 +500,7 @@ where
                 .clone()
                 .unwrap_or_else(|| {
                     SumcheckSingle::from_extension_evals(
-                        folded_evaluations.clone(),
+                        folded_evaluations.parallel_clone(),
                         &round_state.statement,
                         EF::ONE,
                     )

--- a/src/whir/prover/round.rs
+++ b/src/whir/prover/round.rs
@@ -145,7 +145,7 @@ where
 
             // Create the sumcheck prover
             let mut sumcheck = SumcheckSingle::from_base_evals(
-                witness.pol_evals.clone(),
+                witness.pol_evals.parallel_clone(), // TODO I think we could avoid cloning here
                 &statement,
                 combination_randomness_gen,
             );

--- a/src/whir/statement/mod.rs
+++ b/src/whir/statement/mod.rs
@@ -2,7 +2,9 @@ use p3_field::{ExtensionField, Field};
 use tracing::instrument;
 use weights::Weights;
 
-use crate::{poly::evals::EvaluationsList, whir::statement::constraint::Constraint};
+use crate::{
+    poly::evals::EvaluationsList, utils::uninitialized_vec, whir::statement::constraint::Constraint,
+};
 
 pub mod constraint;
 pub mod weights;
@@ -146,11 +148,7 @@ impl<F: Field> Statement<F> {
         // Alloc memory without initializing it to zero.
         // This is safe because there is at least one constraint (otherwise it would return early),
         // and the first iteration of the loop will overwrite the entire vector.
-        let mut evaluations_vec: Vec<F> = Vec::with_capacity(1 << self.num_variables);
-        #[allow(clippy::uninit_vec)]
-        unsafe {
-            evaluations_vec.set_len(1 << self.num_variables);
-        }
+        let evaluations_vec = unsafe { uninitialized_vec::<F>(1 << self.num_variables) };
         let mut combined_evals = EvaluationsList::new(evaluations_vec);
         let (combined_sum, _) = self.constraints.iter().enumerate().fold(
             (F::ZERO, F::ONE),


### PR DESCRIPTION
To estimate the speedup:

```
RUSTFLAGS='-C target-cpu=native' cargo test --release --package whir-p3 --lib -- poly::evals::tests::test_parallel_clone --exact --show-output
```

On my machine: the initial clone (at commitment): Before = 40ms. After = 12ms