### PR TITLE
Fix: Stir indicies are always zero

### DIFF
--- a/src/whir/utils.rs
+++ b/src/whir/utils.rs
@@ -53,7 +53,7 @@ where
                 // Pad with zeros at the end if needed
                 raw_bytes.resize(8, 0);
 
-                (acc << 8) | u64::from_be_bytes(raw_bytes.try_into().unwrap()) as usize
+                (acc << 8) | u64::from_le_bytes(raw_bytes.try_into().unwrap()) as usize
             }) % folded_domain_size
         })
         .sorted_unstable()


### PR DESCRIPTION
Modulus domain size operation after appending least significant zeros always gives 0 if field size is 32 bits. This PR changes the bytes order to get intended indices.