### PR TITLE
Remote redundant`Field` bound

### DIFF
--- a/src/domain/general.rs
+++ b/src/domain/general.rs
@@ -1,4 +1,4 @@
-use p3_field::{Field, TwoAdicField};
+use p3_field::TwoAdicField;
 
 use super::radix2::Radix2EvaluationDomain;
 
@@ -12,7 +12,7 @@ pub enum GeneralEvaluationDomain<F> {
     Radix2(Radix2EvaluationDomain<F>),
 }
 
-impl<F: Field + TwoAdicField> GeneralEvaluationDomain<F> {
+impl<F: TwoAdicField> GeneralEvaluationDomain<F> {
     /// Construct a domain that is large enough for evaluations of a polynomial
     /// having `num_coeffs` coefficients.
     ///

--- a/src/domain/radix2.rs
+++ b/src/domain/radix2.rs
@@ -1,4 +1,4 @@
-use p3_field::{Field, TwoAdicField};
+use p3_field::TwoAdicField;
 
 /// Defines a domain over which finite field (I)FFTs can be performed. Works
 /// only for fields that have a large multiplicative subgroup of size that is
@@ -26,7 +26,7 @@ pub struct Radix2EvaluationDomain<F> {
     pub offset_pow_size: F,
 }
 
-impl<F: Field + TwoAdicField> Radix2EvaluationDomain<F> {
+impl<F: TwoAdicField> Radix2EvaluationDomain<F> {
     #[must_use]
     pub fn new(num_coeffs: usize) -> Option<Self> {
         let size = num_coeffs.next_power_of_two() as u64;

--- a/src/fiat_shamir/domain_separator.rs
+++ b/src/fiat_shamir/domain_separator.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_field::{ExtensionField, TwoAdicField};
 
 use crate::{
     fiat_shamir::{
@@ -53,7 +53,7 @@ pub struct DomainSeparator<EF, F> {
 impl<EF, F> DomainSeparator<EF, F>
 where
     EF: ExtensionField<F> + TwoAdicField,
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
 {
     #[must_use]
     pub const fn from_pattern(pattern: Vec<F>) -> Self {

--- a/src/sumcheck/sumcheck_single_skip.rs
+++ b/src/sumcheck/sumcheck_single_skip.rs
@@ -1,5 +1,5 @@
 use p3_dft::{NaiveDft, TwoAdicSubgroupDft};
-use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 #[cfg(feature = "parallel")]
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
@@ -9,7 +9,7 @@ use crate::poly::evals::EvaluationStorage;
 
 impl<F, EF> SumcheckSingle<F, EF>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F>,
 {
     /// Computes the sumcheck polynomial using the **univariate skip** optimization,

--- a/src/whir/committer/reader.rs
+++ b/src/whir/committer/reader.rs
@@ -134,7 +134,7 @@ where
 
 impl<'a, EF, F, H, C, Challenger> CommitmentReader<'a, EF, F, H, C, Challenger>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -35,7 +35,7 @@ where
 
 impl<'a, EF, F, H, C, Challenger> CommitmentWriter<'a, EF, F, H, C, Challenger>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {

--- a/src/whir/parameters.rs
+++ b/src/whir/parameters.rs
@@ -70,7 +70,7 @@ where
 
 impl<EF, F, MyChallenger, C, Challenger> WhirConfig<EF, F, MyChallenger, C, Challenger>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -55,7 +55,7 @@ where
 
 impl<EF, F, H, C, Challenger> Prover<'_, EF, F, H, C, Challenger>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {

--- a/src/whir/prover/round.rs
+++ b/src/whir/prover/round.rs
@@ -1,5 +1,5 @@
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
 use p3_merkle_tree::MerkleTree;
 use tracing::{info_span, instrument};
@@ -29,7 +29,7 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct RoundState<EF, F, W, M, const DIGEST_ELEMS: usize>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
 {
     /// The domain used in this round, including the size and generator.
@@ -69,7 +69,7 @@ where
 #[allow(clippy::mismatching_type_param_order)]
 impl<EF, F, const DIGEST_ELEMS: usize> RoundState<EF, F, F, DenseMatrix<F>, DIGEST_ELEMS>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
 {
     /// Initializes the prover’s state for the first round of the WHIR protocol.

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -41,7 +41,7 @@ where
 
 impl<'a, EF, F, H, C, Challenger> Verifier<'a, EF, F, H, C, Challenger>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {

--- a/src/whir/verifier/sumcheck.rs
+++ b/src/whir/verifier/sumcheck.rs
@@ -1,5 +1,5 @@
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_field::{ExtensionField, Field, TwoAdicField};
+use p3_field::{ExtensionField, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
 use p3_matrix::dense::RowMajorMatrix;
 
@@ -18,7 +18,7 @@ type SumcheckRandomness<F> = MultilinearPoint<F>;
 
 impl<EF, F, MyChallenger, C, Challenger> Verifier<'_, EF, F, MyChallenger, C, Challenger>
 where
-    F: Field + TwoAdicField,
+    F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {


### PR DESCRIPTION
`TwoAdicField` already extends `Field`