### PR TITLE
reduce the amount of grinding (was slowing everything down) 

### DIFF
--- a/benches/whir.rs
+++ b/benches/whir.rs
@@ -11,7 +11,7 @@ use whir_p3::{
     dft::EvalsDft,
     fiat_shamir::domain_separator::DomainSeparator,
     parameters::{
-        FoldingFactor, MultivariateParameters, ProtocolParameters, default_max_pow,
+        DEFAULT_MAX_POW, FoldingFactor, MultivariateParameters, ProtocolParameters,
         errors::SecurityAssumption,
     },
     poly::{evals::EvaluationsList, multilinear::MultilinearPoint},
@@ -49,7 +49,7 @@ fn prepare_inputs() -> (
     let num_variables = 24;
 
     // Number of PoW bits required, computed based on the domain size and rate.
-    let pow_bits = default_max_pow(num_variables, 1);
+    let pow_bits = DEFAULT_MAX_POW;
 
     // Folding factor `k`: number of variables folded per round in the sumcheck.
     let folding_factor = FoldingFactor::Constant(4);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -17,7 +17,7 @@ use whir_p3::{
     dft::EvalsDft,
     fiat_shamir::domain_separator::DomainSeparator,
     parameters::{
-        FoldingFactor, MultivariateParameters, ProtocolParameters, default_max_pow,
+        DEFAULT_MAX_POW, FoldingFactor, MultivariateParameters, ProtocolParameters,
         errors::SecurityAssumption,
     },
     poly::{evals::EvaluationsList, multilinear::MultilinearPoint},
@@ -45,7 +45,7 @@ type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    #[arg(short = 'l', long, default_value = "100")]
+    #[arg(short = 'l', long, default_value = "95")]
     security_level: usize,
 
     #[arg(short = 'p', long)]
@@ -83,7 +83,7 @@ fn main() {
     let mut args = Args::parse();
 
     if args.pow_bits.is_none() {
-        args.pow_bits = Some(default_max_pow(args.num_variables, args.rate));
+        args.pow_bits = Some(DEFAULT_MAX_POW);
     }
 
     // Runs as a PCS

--- a/src/parameters/mod.rs
+++ b/src/parameters/mod.rs
@@ -10,14 +10,7 @@ pub mod errors;
 /// the prover sends directly the coefficients of the polynomial.
 const MAX_NUM_VARIABLES_TO_SEND_COEFFS: usize = 6;
 
-/// Computes the default maximum proof-of-work (PoW) bits.
-///
-/// This function determines the PoW security level based on the number of variables
-/// and the logarithmic inverse rate.
-#[must_use]
-pub const fn default_max_pow(num_variables: usize, log_inv_rate: usize) -> usize {
-    num_variables + log_inv_rate - 3
-}
+pub const DEFAULT_MAX_POW: usize = 16;
 
 /// Represents the parameters for a multivariate polynomial.
 #[derive(Debug, Clone, Copy)]
@@ -221,17 +214,6 @@ impl<H, C> Display for ProtocolParameters<H, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_default_max_pow() {
-        // Basic cases
-        assert_eq!(default_max_pow(10, 3), 10); // 10 + 3 - 3 = 10
-        assert_eq!(default_max_pow(5, 2), 4); // 5 + 2 - 3 = 4
-
-        // Edge cases
-        assert_eq!(default_max_pow(1, 3), 1); // Smallest valid input
-        assert_eq!(default_max_pow(0, 3), 0); // Zero variables (should not happen in practice)
-    }
 
     #[test]
     fn test_multivariate_parameters() {


### PR DESCRIPTION
+ needed to go to 95 bits of security (in the default program in main.rs) to avoid "WARN: more PoW bits required than what specified"

(security bits can always be set to 128 bits using a bigger extension field)