### PR TITLE
Make initial evaluation storage optional

### DIFF
--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -192,7 +192,7 @@ where
         Ok((constraint_eval, deferred))
     }
 
-    #[instrument(skip_all, fields(round_number = round_index, log_size = round_state.evaluations.num_variables()))]
+    // #[instrument(skip_all, fields(round_number = round_index, log_size = round_state.evaluations.num_variables()))]
     #[allow(clippy::too_many_lines)]
     fn round<const DIGEST_ELEMS: usize>(
         &self,
@@ -221,7 +221,9 @@ where
             }
         } else {
             round_state
-                .evaluations
+                .initial_evaluations
+                .as_ref()
+                .unwrap()
                 .fold(&round_state.folding_randomness)
         };
 
@@ -418,7 +420,6 @@ where
         round_state.domain = new_domain;
         round_state.sumcheck_prover = Some(sumcheck_prover);
         round_state.folding_randomness = folding_randomness;
-        round_state.evaluations = EvaluationStorage::Extension(folded_evaluations);
         round_state.merkle_prover_data = Some(prover_data);
 
         Ok(())

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -192,7 +192,7 @@ where
         Ok((constraint_eval, deferred))
     }
 
-    // #[instrument(skip_all, fields(round_number = round_index, log_size = round_state.evaluations.num_variables()))]
+    #[instrument(skip_all, fields(round_number = round_index, log_size = self.mv_parameters.num_variables - self.folding_factor.total_number(round_index)))]
     #[allow(clippy::too_many_lines)]
     fn round<const DIGEST_ELEMS: usize>(
         &self,


### PR DESCRIPTION
Evaluations in `RoundState` is only required once if there is no initial statement otherwise it is useless and allocates good amount of memory. This PR makes it optional