### PR TITLE
fix grinding (was done after query, instead of before)

### DIFF
--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -422,8 +422,7 @@ where
         // Apply rest of sumcheck rounds
         res.extend(
             (1..folding_factor)
-                .map(|_| round(prover_state, &mut evals, &mut weights, &mut sum, pow_bits))
-                .collect::<Vec<_>>(),
+                .map(|_| round(prover_state, &mut evals, &mut weights, &mut sum, pow_bits)),
         );
 
         // Reverse challenges to maintain order from X₀ to Xₙ.
@@ -499,8 +498,7 @@ where
         // Apply rest of sumcheck rounds
         res.extend(
             (k_skip..folding_factor)
-                .map(|_| round(prover_state, &mut evals, &mut weights, &mut sum, pow_bits))
-                .collect::<Vec<_>>(),
+                .map(|_| round(prover_state, &mut evals, &mut weights, &mut sum, pow_bits)),
         );
 
         // Reverse challenges to maintain order from X₀ to Xₙ.

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -259,6 +259,19 @@ where
             |point| info_span!("ood evaluation").in_scope(|| folded_evaluations.evaluate(point)),
         );
 
+        // CRITICAL: Perform proof-of-work grinding to finalize the transcript before querying.
+        //
+        // This is a crucial security step to prevent a malicious prover from influencing the
+        // verifier's challenges.
+        //
+        // The verifier's query locations (the `stir_challenges`) are generated based on the
+        // current transcript state, which includes the prover's polynomial commitment (the Merkle
+        // root) for this round. Without grinding, a prover could repeatedly try different
+        // commitments until they find one that results in "easy" queries, breaking soundness.
+        //
+        // By forcing the prover to perform this expensive proof-of-work *after* committing but
+        // *before* receiving the queries, we make it computationally infeasible to "shop" for
+        // favorable challenges. The grinding effectively "locks in" the prover's commitment.
         prover_state.pow_grinding(round_params.pow_bits);
 
         // STIR Queries

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -259,6 +259,8 @@ where
             |point| info_span!("ood evaluation").in_scope(|| folded_evaluations.evaluate(point)),
         );
 
+        prover_state.pow_grinding(round_params.pow_bits);
+
         // STIR Queries
         let (stir_challenges, stir_challenges_indexes) = self.compute_stir_queries(
             round_index,
@@ -344,8 +346,6 @@ where
             }
         };
 
-        prover_state.pow_grinding(round_params.pow_bits);
-
         // Randomness for combination
         let combination_randomness_gen: EF = prover_state.sample();
         let combination_randomness: Vec<_> = combination_randomness_gen
@@ -402,6 +402,8 @@ where
     {
         // Directly send coefficients of the polynomial to the verifier.
         prover_state.add_extension_scalars(&round_state.sumcheck_prover.evals);
+
+        prover_state.pow_grinding(self.final_pow_bits);
 
         // Final verifier queries and answers. The indices are over the folded domain.
         let final_challenge_indexes = get_challenge_stir_queries(
@@ -467,8 +469,6 @@ where
                 }
             }
         }
-
-        prover_state.pow_grinding(self.final_pow_bits);
 
         // Run final sumcheck if required
         if self.final_sumcheck_rounds > 0 {

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -283,6 +283,20 @@ where
     {
         let leafs_base_field = round_index == 0;
 
+        // CRITICAL: Verify the prover's proof-of-work before generating challenges.
+        //
+        // This is the verifier's counterpart to the prover's grinding step and is essential
+        // for protocol soundness.
+        //
+        // The query locations (`stir_challenges_indexes`) we are about to generate are derived
+        // from the transcript, which includes the prover's commitment for this round. To prevent
+        // a malicious prover from repeatedly trying different commitments until they find one that
+        // produces "easy" queries, the protocol forces the prover to perform an expensive
+        // proof-of-work (grinding) after they commit.
+        //
+        // By verifying that proof-of-work *now*, we confirm that the prover "locked in" their
+        // commitment at a significant computational cost. This gives us confidence that the
+        // challenges we generate are unpredictable and unbiased by a cheating prover.
         verifier_state.check_pow_grinding(params.pow_bits)?;
 
         let stir_challenges_indexes = get_challenge_stir_queries(

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -283,6 +283,8 @@ where
     {
         let leafs_base_field = round_index == 0;
 
+        verifier_state.check_pow_grinding(params.pow_bits)?;
+
         let stir_challenges_indexes = get_challenge_stir_queries(
             params.domain_size,
             params.folding_factor,
@@ -302,8 +304,6 @@ where
             leafs_base_field,
             round_index,
         )?;
-
-        verifier_state.check_pow_grinding(params.pow_bits)?;
 
         // Compute STIR Constraints
         let folds: Vec<_> = answers


### PR DESCRIPTION
As described in section 6.3 of the [EthStark paper](https://eprint.iacr.org/2021/582.pdf), grinding should be done "before" queries. Because a typical attack against FRI/WHIR is to get "lucky" indexes, after having sent a polynomial which does not correspond to the folding of the previously committed (via merkle root of evaluations) polynomial. So we want the grinding work to appear during each iteration of the search for these "lucky" indexes, not after, once they are found.