### PR TITLE
Angus/add new equality base

### DIFF
--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -578,6 +578,9 @@ where
 
     /// Adds new weighted constraints to the polynomial.
     ///
+    /// Similar to `add_new_equality`, but specifically for constraints involving points
+    /// in the base field.
+    ///
     /// This function updates the weight evaluations and sum by incorporating new constraints.
     ///
     /// Given points `z_i`, weights `ε_i`, and evaluation values `f(z_i)`, it updates:

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -370,7 +370,6 @@ where
             .take(stir_challenges.len())
             .collect::<Vec<_>>();
 
-        // TODO here we could gain performance by removing the embedding from F to EF
         round_state.sumcheck_prover.add_new_base_equality(
             &stir_challenges,
             &stir_evaluations,

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -371,11 +371,8 @@ where
             .collect::<Vec<_>>();
 
         // TODO here we could gain performance by removing the embedding from F to EF
-        round_state.sumcheck_prover.add_new_equality(
-            &stir_challenges
-                .iter()
-                .map(MultilinearPoint::embed)
-                .collect::<Vec<_>>(),
+        round_state.sumcheck_prover.add_new_base_equality(
+            &stir_challenges,
             &stir_evaluations,
             &stir_combination_randomness,
         );


### PR DESCRIPTION
Another take on #232  which should ideally close #227.

Currently quite a bit of copy/pasted code so I want to cut down on that before merging.

Seems to give a 20-30% speed up (looking at the time taken for the second ` accumulate_weight_buffer` when running cargo --run --release). Want to try out a couple of different approaches to.
