### PR TITLE
rm more par_branches

### DIFF
--- a/src/whir/pcs/prover_data.rs
+++ b/src/whir/pcs/prover_data.rs
@@ -196,12 +196,9 @@ impl ConcatMatsMeta {
                 // Evaluate the rotated query as a multilinear polynomial.
                 let query_evals = query.to_mle(F::ONE);
 
-                // Choose the appropriate iterator depending on the build configuration.
-                #[cfg(feature = "parallel")]
+                // If parallel feature is not enables, this will falls back
+                // to into_iter().
                 let range_iter = self.ranges[idx].clone().into_par_iter();
-
-                #[cfg(not(feature = "parallel"))]
-                let range_iter = self.ranges[idx].clone();
 
                 // Compute the constraint weights for each cell in the matrix.
                 //


### PR DESCRIPTION
Final PR related to #235 

Just removing some of the final branches. We can't use `reduce` as the iterator and parallel iterator `reduce` methods have different type signatures. To get around this, `p3_maybe_rayon` introduces `par_fold_reduce`.