### PR TITLE
Derive first coeff of sumcheck poly

### DIFF
--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -131,7 +131,8 @@ where
 {
     // Compute the quadratic sumcheck polynomial for the current variable.
     let sumcheck_poly = compute_sumcheck_polynomial(evals, weights, *sum);
-    prover_state.add_extension_scalars(sumcheck_poly.evaluations());
+    prover_state.add_extension_scalar(sumcheck_poly.evaluations()[0]);
+    prover_state.add_extension_scalar(sumcheck_poly.evaluations()[2]);
 
     // Sample verifier challenge.
     let r: EF = prover_state.sample();
@@ -174,7 +175,8 @@ where
 {
     // Compute the quadratic sumcheck polynomial for the current variable.
     let sumcheck_poly = compute_sumcheck_polynomial(evals, weights, *sum);
-    prover_state.add_extension_scalars(sumcheck_poly.evaluations());
+    prover_state.add_extension_scalar(sumcheck_poly.evaluations()[0]);
+    prover_state.add_extension_scalar(sumcheck_poly.evaluations()[2]);
 
     // Sample verifier challenge.
     let r: EF = prover_state.sample();


### PR DESCRIPTION
Prover can send `c0` and `c2` of sumcheck polynomial and verifier can recover `c1` by doing cheap `current_sum - c0`. So for each sumcheck round, this PR saves 1 ext field element from proof data