### PR TITLE
poly eval list: faster `eval_multilinear`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,7 @@ harness = false
 [[bench]]
 name = "lagrange"
 harness = false
+
+[[bench]]
+name = "eval_multilinear"
+harness = false

--- a/benches/eval_multilinear.rs
+++ b/benches/eval_multilinear.rs
@@ -1,0 +1,48 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use p3_baby_bear::BabyBear;
+use p3_field::extension::BinomialExtensionField;
+use rand::Rng;
+use whir_p3::poly::{evals::EvaluationsList, multilinear::MultilinearPoint};
+
+type F = BabyBear;
+type EF4 = BinomialExtensionField<F, 4>;
+
+fn bench_eval_multilinear(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eval_multilinear");
+
+    for num_vars in (8..=22).step_by(2) {
+        let num_evals = 1 << num_vars;
+
+        let throughput = Throughput::Bytes((num_evals * std::mem::size_of::<F>()) as u64);
+        group.throughput(throughput);
+
+        // Each benchmark is identified by the number of variables.
+        let bench_id = BenchmarkId::from_parameter(num_vars);
+
+        group.bench_with_input(bench_id, &num_vars, |b, &n_vars| {
+            let mut rng = rand::rng();
+
+            // Setup closure: Generate random evaluation data and a random point.
+            let setup = || {
+                let evals_vec: Vec<F> = (0..1 << n_vars).map(|_| rng.random()).collect();
+                let evals_list = EvaluationsList::new(evals_vec);
+
+                let point_vec: Vec<EF4> = (0..n_vars).map(|_| rng.random()).collect();
+                let point = MultilinearPoint(point_vec);
+
+                (evals_list, point)
+            };
+
+            let routine = |(evals_list, point): (EvaluationsList<F>, MultilinearPoint<EF4>)| {
+                std::hint::black_box(evals_list.evaluate(std::hint::black_box(&point)));
+            };
+
+            b.iter_batched(setup, routine, criterion::BatchSize::SmallInput);
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_eval_multilinear);
+
+criterion_main!(benches);


### PR DESCRIPTION
I've added a benchmark file to confirm this approach is faster than the previous one cc @kilic

Here are the results (seems like to be faster for a number of variables > 20)

```shell
Gnuplot not found, using plotters backend
eval_multilinear/8      time:   [2.5308 µs 2.5409 µs 2.5557 µs]
                        thrpt:  [382.12 MiB/s 384.34 MiB/s 385.87 MiB/s]
                 change:
                        time:   [−0.6880% −0.4078% −0.1204%] (p = 0.01 < 0.05)
                        thrpt:  [+0.1205% +0.4095% +0.6928%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
eval_multilinear/10     time:   [10.000 µs 10.039 µs 10.090 µs]
                        thrpt:  [387.16 MiB/s 389.11 MiB/s 390.62 MiB/s]
                 change:
                        time:   [+0.1251% +0.4369% +0.8126%] (p = 0.01 < 0.05)
                        thrpt:  [−0.8061% −0.4350% −0.1249%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
eval_multilinear/12     time:   [39.818 µs 39.929 µs 40.136 µs]
                        thrpt:  [389.31 MiB/s 391.32 MiB/s 392.41 MiB/s]
                 change:
                        time:   [−0.1815% +0.1435% +0.5097%] (p = 0.51 > 0.05)
                        thrpt:  [−0.5071% −0.1433% +0.1818%]
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
eval_multilinear/14     time:   [111.06 µs 111.82 µs 112.67 µs]
                        thrpt:  [554.72 MiB/s 558.95 MiB/s 562.76 MiB/s]
                 change:
                        time:   [−0.3860% +1.2980% +2.9472%] (p = 0.14 > 0.05)
                        thrpt:  [−2.8628% −1.2814% +0.3875%]
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
eval_multilinear/16     time:   [170.89 µs 177.61 µs 185.73 µs]
                        thrpt:  [1.3145 GiB/s 1.3746 GiB/s 1.4287 GiB/s]
                 change:
                        time:   [−1.5865% +3.2078% +7.9018%] (p = 0.18 > 0.05)
                        thrpt:  [−7.3231% −3.1081% +1.6121%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
eval_multilinear/18     time:   [525.08 µs 545.14 µs 566.92 µs]
                        thrpt:  [1.7226 GiB/s 1.7914 GiB/s 1.8598 GiB/s]
                 change:
                        time:   [+12.254% +17.242% +22.192%] (p = 0.00 < 0.05)
                        thrpt:  [−18.162% −14.707% −10.916%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
eval_multilinear/20     time:   [1.3024 ms 1.3353 ms 1.3865 ms]
                        thrpt:  [2.8174 GiB/s 2.9253 GiB/s 2.9993 GiB/s]
                 change:
                        time:   [−14.744% −10.686% −6.9548%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4747% +11.964% +17.294%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
eval_multilinear/22     time:   [3.5808 ms 3.6342 ms 3.7030 ms]
                        thrpt:  [4.2196 GiB/s 4.2995 GiB/s 4.3636 GiB/s]
                 change:
                        time:   [−33.424% −31.845% −30.051%] (p = 0.00 < 0.05)
                        thrpt:  [+42.962% +46.725% +50.203%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
```