### PR TITLE
Remove Deref from Multilinear Point

### DIFF
--- a/src/poly/coeffs.rs
+++ b/src/poly/coeffs.rs
@@ -66,7 +66,7 @@ where
         let folding_factor = folding_randomness.num_variables();
         CoefficientList(
             self.par_chunks_exact(1 << folding_factor)
-                .map(|coeffs| eval_multivariate(coeffs, folding_randomness))
+                .map(|coeffs| eval_multivariate(coeffs, folding_randomness.as_slice()))
                 .collect(),
         )
     }
@@ -78,7 +78,7 @@ where
     #[instrument(skip_all, fields(size = point.num_variables()), level = "debug")]
     pub fn evaluate<EF: ExtensionField<F>>(&self, point: &MultilinearPoint<EF>) -> EF {
         assert_eq!(self.num_variables(), point.num_variables());
-        eval_extension_par(self, point)
+        eval_extension_par(self, point.as_slice())
     }
 }
 

--- a/src/poly/evals.rs
+++ b/src/poly/evals.rs
@@ -106,7 +106,7 @@ where
     where
         EF: ExtensionField<F>,
     {
-        eval_multilinear(self, point)
+        eval_multilinear(self, point.as_slice())
     }
 
     /// Evaluates the polynomial as a constant.
@@ -156,7 +156,7 @@ where
         let folding_factor = folding_randomness.num_variables();
         let evals = self
             .par_chunks_exact(1 << folding_factor)
-            .map(|ev| eval_multilinear(ev, folding_randomness))
+            .map(|ev| eval_multilinear(ev, folding_randomness.as_slice()))
             .collect();
 
         EvaluationsList(evals)
@@ -517,7 +517,7 @@ mod tests {
         let result = evals.evaluate(&point);
 
         // Expected result using `eval_multilinear`
-        let expected = eval_multilinear(&evals, &point);
+        let expected = eval_multilinear(&evals, point.as_slice());
 
         assert_eq!(result, expected);
     }

--- a/src/poly/multilinear.rs
+++ b/src/poly/multilinear.rs
@@ -1,9 +1,9 @@
+use core::ops::{Index, Range};
 use p3_field::Field;
 use rand::{
     Rng,
     distr::{Distribution, StandardUniform},
 };
-use core::ops::{Index, Range};
 
 /// A point `(x_1, ..., x_n)` in `F^n` for some field `F`.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]

--- a/src/poly/multilinear.rs
+++ b/src/poly/multilinear.rs
@@ -34,12 +34,6 @@ where
         self.0.iter()
     }
 
-    /// Return a mutable iterator over the field elements making up the point.
-    #[inline]
-    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, F> {
-        self.0.iter_mut()
-    }
-
     /// Return a sub-point over the specified range of variables.
     #[inline]
     #[must_use]
@@ -164,14 +158,6 @@ impl<'a, F> IntoIterator for &'a MultilinearPoint<F> {
     type IntoIter = std::slice::Iter<'a, F>;
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
-    }
-}
-
-impl<'a, F> IntoIterator for &'a mut MultilinearPoint<F> {
-    type Item = &'a mut F;
-    type IntoIter = std::slice::IterMut<'a, F>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
     }
 }
 

--- a/src/poly/multilinear.rs
+++ b/src/poly/multilinear.rs
@@ -28,25 +28,31 @@ where
         &self.0
     }
 
+    /// Return an iterator over the field elements making up the point.
     #[inline]
     pub fn iter(&self) -> core::slice::Iter<'_, F> {
         self.0.iter()
     }
 
+    /// Return a mutable iterator over the field elements making up the point.
     #[inline]
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, F> {
         self.0.iter_mut()
     }
 
+    /// Return a sub-point over the specified range of variables.
     #[inline]
     #[must_use]
-    pub fn get_range(&self, idx: Range<usize>) -> Self {
+    pub fn get_subpoint_over_range(&self, idx: Range<usize>) -> Self {
         Self(self.0[idx].to_vec())
     }
 
+    /// Return a reference to the last variable in the point, if it exists.
+    ///
+    /// Returns None if the point is empty.
     #[inline]
     #[must_use]
-    pub fn last(&self) -> Option<&F> {
+    pub fn last_variable(&self) -> Option<&F> {
         self.0.last()
     }
 

--- a/src/poly/multilinear.rs
+++ b/src/poly/multilinear.rs
@@ -1,4 +1,5 @@
 use core::ops::{Index, Range};
+
 use p3_field::Field;
 use rand::{
     Rng,
@@ -151,7 +152,6 @@ where
         Self((0..num_variables).map(|_| rng.random()).collect())
     }
 }
-
 
 impl<'a, F> IntoIterator for &'a MultilinearPoint<F> {
     type Item = &'a F;

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -500,7 +500,7 @@ where
                 .iter()
                 .zip(combination_randomness.iter())
                 .for_each(|(point, &rand)| {
-                    eval_eq::<_, _, true>(point, &mut self.weights, rand);
+                    eval_eq::<_, _, true>(point.as_slice(), &mut self.weights, rand);
                 });
         });
 
@@ -549,7 +549,7 @@ where
                 .iter()
                 .zip(combination_randomness.iter())
                 .for_each(|(point, &rand)| {
-                    eval_eq_base::<_, _, true>(point, &mut self.weights, rand);
+                    eval_eq_base::<_, _, true>(point.as_slice(), &mut self.weights, rand);
                 });
         });
 

--- a/src/sumcheck/tests.rs
+++ b/src/sumcheck/tests.rs
@@ -713,8 +713,8 @@ where
 
     // - r0 is the **last** element (skip challenge),
     // - "rest" are the first n-k challenges for the remaining variables.
-    let r0 = *r_all.last().unwrap();
-    let rest = r_all.get_range(0..(n - k_skip));
+    let r0 = *r_all.last_variable().unwrap();
+    let rest = r_all.get_subpoint_over_range(0..(n - k_skip));
 
     // Reshape f into 2^k × 2^{n-k}, interpolate along the skipped dimension at r0,
     // then evaluate the resulting EF-table on the remaining variables.

--- a/src/sumcheck/tests.rs
+++ b/src/sumcheck/tests.rs
@@ -705,16 +705,16 @@ where
     // [ r_for_remaining_vars...,  r_skip ]
     let need = 1 + (n - k_skip);
     assert!(
-        r_all.len() >= need,
+        r_all.num_variables() >= need,
         "need {} challenges (1 + n - k), got {}",
         need,
-        r_all.len()
+        r_all.num_variables()
     );
 
     // - r0 is the **last** element (skip challenge),
     // - "rest" are the first n-k challenges for the remaining variables.
     let r0 = *r_all.last().unwrap();
-    let rest = MultilinearPoint(r_all[..(n - k_skip)].to_vec());
+    let rest = r_all.get_range(0..(n - k_skip));
 
     // Reshape f into 2^k × 2^{n-k}, interpolate along the skipped dimension at r0,
     // then evaluate the resulting EF-table on the remaining variables.

--- a/src/whir/pcs/prover_data.rs
+++ b/src/whir/pcs/prover_data.rs
@@ -173,7 +173,7 @@ impl ConcatMatsMeta {
                 // We assemble the point in order of significance: offset -> row -> column.
                 let point = {
                     // 1. Offset bits (most significant), generated in big-endian order.
-                    let num_non_offset_vars = z.len() + r.len();
+                    let num_non_offset_vars = z.num_variables() + r.len();
                     let num_offset_vars = self.log_b - num_non_offset_vars;
 
                     let offset_vars = (0..num_offset_vars).map(|i| {

--- a/src/whir/pcs/query.rs
+++ b/src/whir/pcs/query.rs
@@ -65,9 +65,9 @@ where
     /// # Returns
     /// The number of variables (length of the `z` vector).
     #[must_use]
-    pub fn log_b(&self) -> usize {
+    pub const fn log_b(&self) -> usize {
         match self {
-            Self::Eq(z) | Self::EqRotateRight(z, _) => z.len(),
+            Self::Eq(z) | Self::EqRotateRight(z, _) => z.num_variables(),
         }
     }
 
@@ -100,10 +100,10 @@ where
             // Standard case: evaluate at z
             Self::Eq(z) => {
                 // Allocate output buffer of size 2^n
-                let mut mle = F::zero_vec(1 << z.len());
+                let mut mle = F::zero_vec(1 << z.num_variables());
 
                 // Fill with α ⋅ eq(x, z) for all x ∈ {0,1}^n
-                eval_eq::<_, _, false>(z, &mut mle, scalar);
+                eval_eq::<_, _, false>(z.as_slice(), &mut mle, scalar);
 
                 mle
             }
@@ -111,10 +111,10 @@ where
             // Rotated case: evaluate at z, then rotate output
             Self::EqRotateRight(z, mid) => {
                 // Allocate output buffer of size 2^n
-                let mut mle = F::zero_vec(1 << z.len());
+                let mut mle = F::zero_vec(1 << z.num_variables());
 
                 // Compute α ⋅ eq(x, z)
-                eval_eq::<_, _, false>(z, &mut mle, scalar);
+                eval_eq::<_, _, false>(z.as_slice(), &mut mle, scalar);
 
                 // Apply circular rotation to output buffer
                 mle.rotate_right(*mid);

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -436,7 +436,7 @@ where
 
         let start_idx = self.folding_factor.total_number(round_index);
         let dst_randomness =
-            &mut round_state.randomness_vec[start_idx..][..folding_randomness.len()];
+            &mut round_state.randomness_vec[start_idx..][..folding_randomness.num_variables()];
 
         for (dst, src) in dst_randomness
             .iter_mut()
@@ -564,7 +564,7 @@ where
                 );
             let start_idx = self.folding_factor.total_number(round_index);
             let rand_dst = &mut round_state.randomness_vec
-                [start_idx..start_idx + final_folding_randomness.len()];
+                [start_idx..start_idx + final_folding_randomness.num_variables()];
 
             for (dst, src) in rand_dst
                 .iter_mut()

--- a/src/whir/prover/round.rs
+++ b/src/whir/prover/round.rs
@@ -498,7 +498,7 @@ mod tests {
         assert_eq!(sumcheck.sum, EF4::ZERO);
 
         // Folding randomness should have length equal to the folding factor (1)
-        assert_eq!(sumcheck_randomness.len(), 1);
+        assert_eq!(sumcheck_randomness.num_variables(), 1);
 
         // The `randomness_vec` is populated in reverse variable order, padded with 0s
         assert_eq!(

--- a/src/whir/statement/evaluator.rs
+++ b/src/whir/statement/evaluator.rs
@@ -504,7 +504,9 @@ mod tests {
         // - `r_skip`.
         let num_remaining = num_vars - K_SKIP_SUMCHECK;
         let r_rest = final_point.get_subpoint_over_range(0..num_remaining);
-        let r_skip = *final_point.last_variable().expect("skip challenge must be present");
+        let r_skip = *final_point
+            .last_variable()
+            .expect("skip challenge must be present");
 
         // b) Reshape the W_0(X) evaluation table into a matrix.
         let w0_mat = RowMajorMatrix::new(w0_combined.to_vec(), 1 << num_remaining);

--- a/src/whir/statement/evaluator.rs
+++ b/src/whir/statement/evaluator.rs
@@ -72,7 +72,7 @@ impl ConstraintPolyEvaluator {
             // take a prefix of length `vars_left`.
             let point_for_round = if round_idx > 0 {
                 vars_left -= self.folding_factor.at_round(round_idx - 1);
-                MultilinearPoint(point[..vars_left].to_vec())
+                point.get_range(0..vars_left)
             } else {
                 point.clone()
             };
@@ -253,7 +253,7 @@ mod tests {
         // Combine the constraints for the second round using its alpha.
         let (w1_combined, _) = statements[1].combine::<F>(alphas[1]);
         // The domain has shrunk. The evaluation point is the first 15 variables of the full point.
-        let point_round1 = MultilinearPoint(final_point[..15].to_vec());
+        let point_round1 = final_point.get_range(0..15);
         // Add the contribution from this round.
         expected_result += w1_combined.evaluate(&point_round1);
 
@@ -262,7 +262,7 @@ mod tests {
         // Combine the constraints for the third round.
         let (w2_combined, _) = statements[2].combine::<F>(alphas[2]);
         // The domain shrinks again. The evaluation point is the first 10 variables of the full point.
-        let point_round2 = MultilinearPoint(final_point[..10].to_vec());
+        let point_round2 = final_point.get_range(0..10);
         // Add the contribution from this round.
         expected_result += w2_combined.evaluate(&point_round2);
 
@@ -389,7 +389,7 @@ mod tests {
                 let (w_combined, _) = statements[i].combine::<F>(alphas[i]);
 
                 // Create the challenge point for this round by taking a prefix slice of the full point `r`.
-                let point_for_round = MultilinearPoint(final_point[..num_vars_for_round].to_vec());
+                let point_for_round = final_point.get_range(0..num_vars_for_round);
                 // Evaluate `W_i` at the correctly sliced point.
                 let w_eval = w_combined.evaluate(&point_for_round);
 
@@ -503,7 +503,7 @@ mod tests {
         // - `r_rest`,
         // - `r_skip`.
         let num_remaining = num_vars - K_SKIP_SUMCHECK;
-        let r_rest = MultilinearPoint(final_point[..num_remaining].to_vec());
+        let r_rest = final_point.get_range(0..num_remaining);
         let r_skip = *final_point.last().expect("skip challenge must be present");
 
         // b) Reshape the W_0(X) evaluation table into a matrix.
@@ -519,17 +519,17 @@ mod tests {
         // --- Contribution from Round 1 (Standard Round) ---
         let (w1_combined, _) = statements[1].combine::<F>(alphas[1]);
         // For subsequent rounds, the evaluation point is a prefix slice of the `r_rest` challenges.
-        let point_round1 = MultilinearPoint(r_rest[..statements[1].num_variables()].to_vec());
+        let point_round1 = r_rest.get_range(0..statements[1].num_variables());
         expected_result += w1_combined.evaluate(&point_round1);
 
         // --- Contribution from Round 2 (Standard Round) ---
         let (w2_combined, _) = statements[2].combine::<F>(alphas[2]);
-        let point_round2 = MultilinearPoint(r_rest[..statements[2].num_variables()].to_vec());
+        let point_round2 = r_rest.get_range(0..statements[2].num_variables());
         expected_result += w2_combined.evaluate(&point_round2);
 
         // --- Contribution from Round 3 (Standard Round) ---
         let (w3_combined, _) = statements[3].combine::<F>(alphas[3]);
-        let point_round3 = MultilinearPoint(r_rest[..statements[3].num_variables()].to_vec());
+        let point_round3 = r_rest.get_range(0..statements[3].num_variables());
         expected_result += w3_combined.evaluate(&point_round3);
 
         // The result from the recursive function must match the materialized ground truth.
@@ -639,8 +639,9 @@ mod tests {
             let (w0_combined, _) = statements[0].combine::<F>(alphas[0]);
             // Evaluate W_0(r) using the manual skip evaluation pipeline.
             let num_remaining = n - K_SKIP_SUMCHECK;
-            let r_rest = MultilinearPoint(final_point[..num_remaining].to_vec());
+            let r_rest = final_point.get_range(0..num_remaining);
             let r_skip = *final_point.last().expect("skip challenge must be present");
+
             let w0_mat = RowMajorMatrix::new(w0_combined.to_vec(), 1 << num_remaining);
             let folded_row = interpolate_subgroup(&w0_mat, r_skip);
             let w0_eval = EvaluationsList::new(folded_row).evaluate(&r_rest);
@@ -655,7 +656,7 @@ mod tests {
                 let (w_combined, _) = statements[i].combine::<F>(alphas[i]);
 
                 // Evaluate `W_i` at the correct prefix slice of the `r_rest` challenges.
-                let point_for_round = MultilinearPoint(r_rest[..num_vars_for_round].to_vec());
+                let point_for_round = r_rest.get_range(0..num_vars_for_round);
                 let w_eval = w_combined.evaluate(&point_for_round);
 
                 // Add this round's contribution to the total.

--- a/src/whir/statement/evaluator.rs
+++ b/src/whir/statement/evaluator.rs
@@ -72,7 +72,7 @@ impl ConstraintPolyEvaluator {
             // take a prefix of length `vars_left`.
             let point_for_round = if round_idx > 0 {
                 vars_left -= self.folding_factor.at_round(round_idx - 1);
-                point.get_range(0..vars_left)
+                point.get_subpoint_over_range(0..vars_left)
             } else {
                 point.clone()
             };
@@ -253,7 +253,7 @@ mod tests {
         // Combine the constraints for the second round using its alpha.
         let (w1_combined, _) = statements[1].combine::<F>(alphas[1]);
         // The domain has shrunk. The evaluation point is the first 15 variables of the full point.
-        let point_round1 = final_point.get_range(0..15);
+        let point_round1 = final_point.get_subpoint_over_range(0..15);
         // Add the contribution from this round.
         expected_result += w1_combined.evaluate(&point_round1);
 
@@ -262,7 +262,7 @@ mod tests {
         // Combine the constraints for the third round.
         let (w2_combined, _) = statements[2].combine::<F>(alphas[2]);
         // The domain shrinks again. The evaluation point is the first 10 variables of the full point.
-        let point_round2 = final_point.get_range(0..10);
+        let point_round2 = final_point.get_subpoint_over_range(0..10);
         // Add the contribution from this round.
         expected_result += w2_combined.evaluate(&point_round2);
 
@@ -389,7 +389,7 @@ mod tests {
                 let (w_combined, _) = statements[i].combine::<F>(alphas[i]);
 
                 // Create the challenge point for this round by taking a prefix slice of the full point `r`.
-                let point_for_round = final_point.get_range(0..num_vars_for_round);
+                let point_for_round = final_point.get_subpoint_over_range(0..num_vars_for_round);
                 // Evaluate `W_i` at the correctly sliced point.
                 let w_eval = w_combined.evaluate(&point_for_round);
 
@@ -503,8 +503,8 @@ mod tests {
         // - `r_rest`,
         // - `r_skip`.
         let num_remaining = num_vars - K_SKIP_SUMCHECK;
-        let r_rest = final_point.get_range(0..num_remaining);
-        let r_skip = *final_point.last().expect("skip challenge must be present");
+        let r_rest = final_point.get_subpoint_over_range(0..num_remaining);
+        let r_skip = *final_point.last_variable().expect("skip challenge must be present");
 
         // b) Reshape the W_0(X) evaluation table into a matrix.
         let w0_mat = RowMajorMatrix::new(w0_combined.to_vec(), 1 << num_remaining);
@@ -519,17 +519,17 @@ mod tests {
         // --- Contribution from Round 1 (Standard Round) ---
         let (w1_combined, _) = statements[1].combine::<F>(alphas[1]);
         // For subsequent rounds, the evaluation point is a prefix slice of the `r_rest` challenges.
-        let point_round1 = r_rest.get_range(0..statements[1].num_variables());
+        let point_round1 = r_rest.get_subpoint_over_range(0..statements[1].num_variables());
         expected_result += w1_combined.evaluate(&point_round1);
 
         // --- Contribution from Round 2 (Standard Round) ---
         let (w2_combined, _) = statements[2].combine::<F>(alphas[2]);
-        let point_round2 = r_rest.get_range(0..statements[2].num_variables());
+        let point_round2 = r_rest.get_subpoint_over_range(0..statements[2].num_variables());
         expected_result += w2_combined.evaluate(&point_round2);
 
         // --- Contribution from Round 3 (Standard Round) ---
         let (w3_combined, _) = statements[3].combine::<F>(alphas[3]);
-        let point_round3 = r_rest.get_range(0..statements[3].num_variables());
+        let point_round3 = r_rest.get_subpoint_over_range(0..statements[3].num_variables());
         expected_result += w3_combined.evaluate(&point_round3);
 
         // The result from the recursive function must match the materialized ground truth.
@@ -639,8 +639,8 @@ mod tests {
             let (w0_combined, _) = statements[0].combine::<F>(alphas[0]);
             // Evaluate W_0(r) using the manual skip evaluation pipeline.
             let num_remaining = n - K_SKIP_SUMCHECK;
-            let r_rest = final_point.get_range(0..num_remaining);
-            let r_skip = *final_point.last().expect("skip challenge must be present");
+            let r_rest = final_point.get_subpoint_over_range(0..num_remaining);
+            let r_skip = *final_point.last_variable().expect("skip challenge must be present");
 
             let w0_mat = RowMajorMatrix::new(w0_combined.to_vec(), 1 << num_remaining);
             let folded_row = interpolate_subgroup(&w0_mat, r_skip);
@@ -656,7 +656,7 @@ mod tests {
                 let (w_combined, _) = statements[i].combine::<F>(alphas[i]);
 
                 // Evaluate `W_i` at the correct prefix slice of the `r_rest` challenges.
-                let point_for_round = r_rest.get_range(0..num_vars_for_round);
+                let point_for_round = r_rest.get_subpoint_over_range(0..num_vars_for_round);
                 let w_eval = w_combined.evaluate(&point_for_round);
 
                 // Add this round's contribution to the total.

--- a/src/whir/statement/weights.rs
+++ b/src/whir/statement/weights.rs
@@ -53,7 +53,7 @@ impl<F: Field> Weights<F> {
 
     /// Returns the number of variables involved in the weight function.
     #[must_use]
-    pub fn num_variables(&self) -> usize {
+    pub const fn num_variables(&self) -> usize {
         match self {
             Self::Evaluation { point } => point.num_variables(),
             Self::Linear { weight } => weight.num_variables(),
@@ -127,7 +127,7 @@ impl<F: Field> Weights<F> {
         assert_eq!(accumulator.num_variables(), self.num_variables());
         match self {
             Self::Evaluation { point } => {
-                eval_eq::<Base, F, INITIALIZED>(point, accumulator, factor);
+                eval_eq::<Base, F, INITIALIZED>(point.as_slice(), accumulator, factor);
             }
             Self::Linear { weight } => {
                 accumulator
@@ -225,7 +225,7 @@ impl<F: Field> Weights<F> {
 
                 // Construct the evaluation table for the polynomial eq_z(X).
                 let mut evals = EvaluationsList::new(F::zero_vec(1 << n));
-                eval_eq::<_, _, false>(point, &mut evals, F::ONE);
+                eval_eq::<_, _, false>(point.as_slice(), &mut evals, F::ONE);
                 evals
             }
         };
@@ -375,7 +375,7 @@ mod tests {
 
         // Compute expected result manually
         let mut expected = vec![F::ZERO, F::ZERO];
-        eval_eq::<_, _, true>(&point, &mut expected, factor);
+        eval_eq::<_, _, true>(point.as_slice(), &mut expected, factor);
 
         assert_eq!(&*accumulator, &expected);
     }

--- a/src/whir/verifier/sumcheck.rs
+++ b/src/whir/verifier/sumcheck.rs
@@ -320,7 +320,7 @@ mod tests {
         .unwrap();
 
         // Check that number of parsed rounds is correct
-        assert_eq!(randomness.len(), folding_factor);
+        assert_eq!(randomness.num_variables(), folding_factor);
 
         // Reconstruct the expected MultilinearPoint from reversed order of expected randomness
         let expected_randomness =
@@ -447,7 +447,7 @@ mod tests {
         // Check length:
         // - 1 randomness for the first K skipped rounds
         // - 1 randomness for each regular round
-        assert_eq!(randomness.len(), NUM_VARS - K_SKIP + 1);
+        assert_eq!(randomness.num_variables(), NUM_VARS - K_SKIP + 1);
 
         // Reconstruct the expected MultilinearPoint from reversed order of expected randomness
         let expected_randomness =


### PR DESCRIPTION
This is a prototype for how we could remove Deref from Multilinear Point.

By construction, Multilinear Point isn't just a vector of values as there is implicit information about what it represents and it comes with some extra functions. If we want to support these, it doesn't really make sense to implement Deref.

For example the codebase is currently littered with example where `len()` and other slice methods are used on Multilinear Point instead of the clearer num_variables(). It's probably the case that these two values are always equal but, if it ever isn't the case, this will lead to a lot of bugs.

TBH I wouldn't merge this as is, I think last and get_range should have more descriptive names but I think this shows that removing deref isn't too hard.

As a side comment, a bunch of places which currently use `as_slice` call functions which should, really be accepting `&MultilinearPoint<F>` instead of `&[F]`. I'm not certain what the right approach is here but it would be good to actually use MultiplierPoint a little more throughout the code. (As opposed to roughly pulling it into existence to call a single one of its methods and then returning to a slice)