### PR TITLE
poly: rm deref and deref mut for `EvaluationsList`

### DIFF
--- a/src/dft.rs
+++ b/src/dft.rs
@@ -544,7 +544,7 @@ mod test {
         let dft = EvalsDft::<F>::default();
         let mut matrix = vec![F::ZERO; (1 << n_vars) * width];
         for (i, pol) in pols.iter().enumerate() {
-            for (j, &eval) in pol.iter().enumerate() {
+            for (j, &eval) in pol.as_slice().iter().enumerate() {
                 matrix[i + j * width] = eval;
             }
         }

--- a/src/poly/coeffs.rs
+++ b/src/poly/coeffs.rs
@@ -477,6 +477,7 @@ mod tests {
         let coeff_list = CoefficientList::new(coeffs);
 
         let evaluations = coeff_list.to_evaluations();
+        let evaluations = evaluations.as_slice();
 
         // Expected results after wavelet transform (manually derived)
         assert_eq!(evaluations[0], coeff0);
@@ -993,7 +994,7 @@ mod tests {
             F::from_u64(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8),
         ];
 
-        assert_eq!(&*eval_list, &expected);
+        assert_eq!(eval_list.as_slice(), &expected);
     }
 
     proptest! {

--- a/src/sumcheck/sumcheck_single_skip.rs
+++ b/src/sumcheck/sumcheck_single_skip.rs
@@ -86,10 +86,10 @@ where
         //
         // This aligns with the goal of computing:
         //   h(X) = ∑_{b ∈ {0,1}^{n−k}} f(X, b) · w(X, b)
-        let f_mat = RowMajorMatrix::new(evals.to_vec(), width);
+        let f_mat = RowMajorMatrix::new(evals.as_slice().to_vec(), width);
 
         // Do the same for the weight polynomial w(X): shape = (2^k × 2^{n-k})
-        let weights_mat = RowMajorMatrix::new(weights.to_vec(), width);
+        let weights_mat = RowMajorMatrix::new(weights.as_slice().to_vec(), width);
 
         // Apply a low-degree extension (LDE) to each row of f_mat and weights_mat.
         // The LDE maps each row of length 2^k to 2^{k+1} evaluations over a multiplicative coset.

--- a/src/sumcheck/tests.rs
+++ b/src/sumcheck/tests.rs
@@ -450,7 +450,7 @@ fn run_sumcheck_test(folding_factors: &[usize], num_points: &[usize]) {
     assert_eq!(sumcheck.evals.num_evals(), 1);
 
     // Final folded value must match f(r)
-    let final_folded_value = sumcheck.evals[0];
+    let final_folded_value = sumcheck.evals.as_slice()[0];
     assert_eq!(poly.evaluate(&prover_randomness), final_folded_value);
     prover.add_extension_scalar(final_folded_value);
 
@@ -617,7 +617,7 @@ fn run_sumcheck_test_skips(folding_factors: &[usize], num_points: &[usize]) {
     assert_eq!(sumcheck.evals.num_evals(), 1);
 
     // Final constant should be f(r), where r is the accumulated challenge point
-    let constant = sumcheck.evals[0];
+    let constant = sumcheck.evals.as_slice()[0];
 
     // Final constant should be f̂(r0, r_{k+1..}) under skip semantics
     let expected = eval_with_skip::<F, EF>(&poly, K_SKIP_SUMCHECK, &prover_randomness);
@@ -743,7 +743,7 @@ where
     // Reshape f into 2^k × 2^{n-k}, interpolate along the skipped dimension at r0,
     // then evaluate the resulting EF-table on the remaining variables.
     let width = 1 << (n - k_skip);
-    let f_mat = RowMajorMatrix::new(poly.to_vec(), width);
+    let f_mat = RowMajorMatrix::new(poly.as_slice().to_vec(), width);
     let folded_row = interpolate_subgroup::<F, EF, _>(&f_mat, r0);
 
     EvaluationsList::new(folded_row).evaluate(&rest)

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -70,7 +70,7 @@ where
         [F; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
     {
         let evals_repeated = info_span!("repeating evals")
-            .in_scope(|| parallel_repeat(&polynomial, 1 << self.starting_log_inv_rate));
+            .in_scope(|| parallel_repeat(polynomial.as_slice(), 1 << self.starting_log_inv_rate));
 
         // Perform DFT on the padded evaluations matrix
         let width = 1 << self.folding_factor.at_round(0);

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -228,7 +228,7 @@ where
         let inv_rate = new_domain_size / folded_evaluations.num_evals();
         let folded_matrix = info_span!("fold matrix").in_scope(|| {
             let evals_repeated = info_span!("repeating evals")
-                .in_scope(|| parallel_repeat(folded_evaluations, inv_rate));
+                .in_scope(|| parallel_repeat(folded_evaluations.as_slice(), inv_rate));
             // Do DFT on only interleaved polys to be folded.
             info_span!(
                 "dft",
@@ -337,7 +337,7 @@ where
                         let width = 1 << num_remaining_vars;
 
                         // Reshape the `answer` evaluations into the `2^k x 2^(n-k)` matrix format.
-                        let mat = RowMajorMatrix::new(evals.to_vec(), width);
+                        let mat = RowMajorMatrix::new(evals.as_slice().to_vec(), width);
 
                         // For a skip round, `folding_randomness` is the special `(n-k)+1` challenge object.
                         let r_all = round_state.folding_randomness.clone();
@@ -475,7 +475,7 @@ where
         [F; DIGEST_ELEMS]: Serialize + for<'de> Deserialize<'de>,
     {
         // Directly send coefficients of the polynomial to the verifier.
-        prover_state.add_extension_scalars(&round_state.sumcheck_prover.evals);
+        prover_state.add_extension_scalars(round_state.sumcheck_prover.evals.as_slice());
 
         // CRITICAL: Perform proof-of-work grinding to finalize the transcript before querying.
         //

--- a/src/whir/prover/round.rs
+++ b/src/whir/prover/round.rs
@@ -406,10 +406,10 @@ mod tests {
         let sumcheck_randomness = state.folding_randomness.clone();
 
         // With a folding factor of 3, all variables are collapsed in 1 round, so we expect only 1 evaluation left
-        assert_eq!(sumcheck.evals.len(), 1);
+        assert_eq!(sumcheck.evals.num_evals(), 1);
 
         // The value of f at the folding point should match the evaluation
-        let eval_at_point = sumcheck.evals[0];
+        let eval_at_point = sumcheck.evals.as_slice()[0];
         let expected = f(
             sumcheck_randomness[0],
             sumcheck_randomness[1],
@@ -420,8 +420,9 @@ mod tests {
         // Check that dot product of evaluations and weights matches the final sum
         let dot_product: EF4 = sumcheck
             .evals
+            .as_slice()
             .iter()
-            .zip(sumcheck.weights.as_ref())
+            .zip(sumcheck.weights.as_slice())
             .map(|(f, w)| *f * *w)
             .sum();
         assert_eq!(dot_product, sumcheck.sum);
@@ -488,7 +489,12 @@ mod tests {
         let sumcheck = &state.sumcheck_prover;
         let sumcheck_randomness = state.folding_randomness.clone();
 
-        for (f, w) in sumcheck.evals.iter().zip(sumcheck.weights.as_ref()) {
+        for (f, w) in sumcheck
+            .evals
+            .as_slice()
+            .iter()
+            .zip(sumcheck.weights.as_slice())
+        {
             // Each evaluation should be 0
             assert_eq!(*f, EF4::ZERO);
             // Their contribution to the weighted sum should also be 0
@@ -591,11 +597,14 @@ mod tests {
             )
         );
 
+        let evals_f = evals_f.as_slice();
+        let weights = sumcheck.weights.as_slice();
+
         // Manually verify that ⟨f, w⟩ = claimed sum
-        let dot_product = evals_f[0] * sumcheck.weights[0]
-            + evals_f[1] * sumcheck.weights[1]
-            + evals_f[2] * sumcheck.weights[2]
-            + evals_f[3] * sumcheck.weights[3];
+        let dot_product = evals_f[0] * weights[0]
+            + evals_f[1] * weights[1]
+            + evals_f[2] * weights[2]
+            + evals_f[3] * weights[3];
         assert_eq!(dot_product, sumcheck.sum);
 
         // No Merkle tree data has been created for folded rounds yet

--- a/src/whir/statement/constraint.rs
+++ b/src/whir/statement/constraint.rs
@@ -165,7 +165,7 @@ mod tests {
         //
         // expected = Σ_i w_i * f_i
         let expected_sum = (0..8)
-            .map(|i| weight_vec[i] * evals[i])
+            .map(|i| weight_vec[i] * evals.as_slice()[i])
             .fold(F::ZERO, |acc, x| acc + x);
 
         let constraint = Constraint {

--- a/src/whir/statement/evaluator.rs
+++ b/src/whir/statement/evaluator.rs
@@ -507,7 +507,7 @@ mod tests {
             .expect("skip challenge must be present");
 
         // b) Reshape the W_0(X) evaluation table into a matrix.
-        let w0_mat = RowMajorMatrix::new(w0_combined.to_vec(), 1 << num_remaining);
+        let w0_mat = RowMajorMatrix::new(w0_combined.as_slice().to_vec(), 1 << num_remaining);
 
         // c) "Fold" the skipped variables by interpolating the matrix at `r_skip`.
         let folded_row = interpolate_subgroup(&w0_mat, r_skip);
@@ -642,7 +642,7 @@ mod tests {
             let r_rest = final_point.get_subpoint_over_range(0..num_remaining);
             let r_skip = *final_point.last_variable().expect("skip challenge must be present");
 
-            let w0_mat = RowMajorMatrix::new(w0_combined.to_vec(), 1 << num_remaining);
+            let w0_mat = RowMajorMatrix::new(w0_combined.as_slice().to_vec(), 1 << num_remaining);
             let folded_row = interpolate_subgroup(&w0_mat, r_skip);
             let w0_eval = EvaluationsList::new(folded_row).evaluate(&r_rest);
             expected_result += w0_eval;

--- a/src/whir/statement/mod.rs
+++ b/src/whir/statement/mod.rs
@@ -245,7 +245,7 @@ mod tests {
         // Expected sum remains unchanged since there is only one constraint
         let expected_combined_sum = sum;
 
-        assert_eq!(&*combined_evals, &expected_combined_evals);
+        assert_eq!(combined_evals.as_slice(), &expected_combined_evals);
         assert_eq!(combined_sum, expected_combined_sum);
     }
 
@@ -307,7 +307,7 @@ mod tests {
         // \end{equation}
         let expected_combined_sum = sum1 + challenge * sum2; // 5 + 2 * 7 = 19
 
-        assert_eq!(&*combined_evals, &expected_combined_evals);
+        assert_eq!(combined_evals.as_slice(), &expected_combined_evals);
         assert_eq!(combined_sum, expected_combined_sum);
     }
 
@@ -441,6 +441,7 @@ mod tests {
         // Evaluate f at every Boolean input in {0,1}²
         // Corner ordering: (0,0), (0,1), (1,0), (1,1)
         let evals = coeffs.clone().to_evaluations();
+        let evals = evals.as_slice();
 
         // Define linear weights w_i for each corner:
         let w0 = F::from_u64(10);

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -352,7 +352,7 @@ where
                     let width = 1 << num_remaining_vars;
 
                     // Reshape the flat `2^n` evaluations into a `2^k x 2^(n-k)` matrix.
-                    let mat = RowMajorMatrix::new(evals.to_vec(), width);
+                    let mat = RowMajorMatrix::new(evals.as_slice().to_vec(), width);
 
                     // The `folding_randomness` for a skip round is the special `(n-k)+1` challenge object.
                     let r_all = folding_randomness.clone();


### PR DESCRIPTION
Related https://github.com/Plonky3/Plonky3/pull/1016

@SyxtonPrime Same problem we had with the multilinear point, I've removed here deref and deref mut to avoid any incorrect behaviour or usage.