### PR TITLE
Chanegs to Evaluation List

### DIFF
--- a/src/dft.rs
+++ b/src/dft.rs
@@ -544,7 +544,7 @@ mod test {
         let dft = EvalsDft::<F>::default();
         let mut matrix = vec![F::ZERO; (1 << n_vars) * width];
         for (i, pol) in pols.iter().enumerate() {
-            for (j, &eval) in pol.as_slice().iter().enumerate() {
+            for (j, &eval) in pol.iter().enumerate() {
                 matrix[i + j * width] = eval;
             }
         }

--- a/src/poly/coeffs.rs
+++ b/src/poly/coeffs.rs
@@ -192,7 +192,6 @@ impl<F> CoefficientList<F> {
 
     /// Convert from a list of multilinear coefficients to a list of
     /// evaluations over the hypercube.
-    #[must_use]
     pub fn to_evaluations<B: Field>(self) -> EvaluationsList<F>
     where
         F: ExtensionField<B>,

--- a/src/poly/evals.rs
+++ b/src/poly/evals.rs
@@ -55,9 +55,16 @@ where
         Self(evals)
     }
 
+    /// Evaluates the polynomial as a constant.
+    /// This is only valid for constant polynomials (i.e., when `num_variables` is 0).
+    /// 
+    /// Returns None in other cases.
+    ///
+    /// # Panics
+    /// Panics if `num_variables` is not 0.
     #[must_use]
-    pub fn get_constant(&self) -> Option<F> {
-        (self.0.len() == 1).then(|| self.0[0])
+    pub fn as_constant(&self) -> Option<F> {
+        (self.num_evals() == 1).then_some(self.0[0])
     }
 
     /// Given a multilinear point `P`, compute the evaluation vector of the equality function `eq(P, X)`

--- a/src/poly/evals.rs
+++ b/src/poly/evals.rs
@@ -57,7 +57,7 @@ where
 
     /// Evaluates the polynomial as a constant.
     /// This is only valid for constant polynomials (i.e., when `num_variables` is 0).
-    /// 
+    ///
     /// Returns None in other cases.
     ///
     /// # Panics
@@ -70,6 +70,7 @@ where
     /// Given a multilinear point `P`, compute the evaluation vector of the equality function `eq(P, X)`
     /// for all points `X` in the boolean hypercube and add it to the current evaluation vector.
     pub fn accumulate(&mut self, point: &MultilinearPoint<F>, value: F) {
+        assert_eq!(self.num_variables(), point.num_variables());
         eval_eq::<_, _, true>(point.as_slice(), &mut self.0, value);
     }
 
@@ -81,6 +82,7 @@ where
     where
         F: ExtensionField<BF>,
     {
+        assert_eq!(self.num_variables(), point.num_variables());
         eval_eq_base::<_, _, true>(point.as_slice(), &mut self.0, value);
     }
 

--- a/src/poly/evals.rs
+++ b/src/poly/evals.rs
@@ -2,14 +2,14 @@ use itertools::Itertools;
 use p3_field::{ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
-use p3_multilinear_util::{eq::{eval_eq, eval_eq_base}, point::MultilinearPoint};
+use p3_multilinear_util::{
+    eq::{eval_eq, eval_eq_base},
+    point::MultilinearPoint,
+};
 use tracing::instrument;
 
 use super::{coeffs::CoefficientList, wavelet::Radix2WaveletKernel};
-use crate::{
-    constant::MLE_RECURSION_THRESHOLD,
-    utils::{uninitialized_vec},
-};
+use crate::{constant::MLE_RECURSION_THRESHOLD, utils::uninitialized_vec};
 
 const PARALLEL_THRESHOLD: usize = 4096;
 
@@ -68,7 +68,7 @@ where
 
     /// Given a multilinear point `P`, compute the evaluation vector of the equality function `eq(P, X)`
     /// for all points `X` in the boolean hypercube and add it to the current evaluation vector.
-    /// 
+    ///
     /// This is a variant of `accumulate` where the new point lies in a sub-field.
     pub fn accumulate_base<BF: Field>(&mut self, point: &MultilinearPoint<BF>, value: F)
     where
@@ -101,8 +101,7 @@ where
     ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
     /// ```
     #[must_use]
-    pub fn evaluate<EF: ExtensionField<F>>(&self, point: &MultilinearPoint<EF>) -> EF
-    {
+    pub fn evaluate<EF: ExtensionField<F>>(&self, point: &MultilinearPoint<EF>) -> EF {
         eval_multilinear(&self.0, point)
     }
 
@@ -216,10 +215,7 @@ where
     ///     p'(X_2, ..., X_n) = (p(1, X_2, ..., X_n) - p(0, X_2, ..., X_n)) \cdot r + p(0, X_2, ..., X_n)
     /// ```
     #[instrument(skip_all)]
-    pub fn compress_ext<EF: ExtensionField<F>>(
-        &self,
-        r: EF,
-    ) -> EvaluationsList<EF> {
+    pub fn compress_ext<EF: ExtensionField<F>>(&self, r: EF) -> EvaluationsList<EF> {
         assert_ne!(self.num_variables(), 0);
 
         // Fold between base and extension field elements

--- a/src/poly/evals.rs
+++ b/src/poly/evals.rs
@@ -37,6 +37,7 @@ where
     ///
     /// # Panics
     /// Panics if `evals.len()` is not a power of two.
+    #[inline]
     pub const fn new(evals: Vec<F>) -> Self {
         assert!(
             evals.len().is_power_of_two(),
@@ -48,6 +49,7 @@ where
 
     /// Given a multilinear point `P`, compute the evaluation vector of the equality function `eq(P, X)`
     /// for all points `X` in the boolean hypercube.
+    #[inline]
     pub fn new_from_point(point: &MultilinearPoint<F>, value: F) -> Self {
         let n = point.num_variables();
         let mut evals = F::zero_vec(1 << n);
@@ -63,12 +65,14 @@ where
     /// # Panics
     /// Panics if `num_variables` is not 0.
     #[must_use]
+    #[inline]
     pub fn as_constant(&self) -> Option<F> {
         (self.num_evals() == 1).then_some(self.0[0])
     }
 
     /// Given a multilinear point `P`, compute the evaluation vector of the equality function `eq(P, X)`
     /// for all points `X` in the boolean hypercube and add it to the current evaluation vector.
+    #[inline]
     pub fn accumulate(&mut self, point: &MultilinearPoint<F>, value: F) {
         assert_eq!(self.num_variables(), point.num_variables());
         eval_eq::<_, _, true>(point.as_slice(), &mut self.0, value);
@@ -78,6 +82,7 @@ where
     /// for all points `X` in the boolean hypercube and add it to the current evaluation vector.
     ///
     /// This is a variant of `accumulate` where the new point lies in a sub-field.
+    #[inline]
     pub fn accumulate_base<BF: Field>(&mut self, point: &MultilinearPoint<BF>, value: F)
     where
         F: ExtensionField<BF>,
@@ -88,12 +93,14 @@ where
 
     /// Returns the total number of stored evaluations.
     #[must_use]
+    #[inline]
     pub const fn num_evals(&self) -> usize {
         self.0.len()
     }
 
     /// Returns the number of variables in the multilinear polynomial.
     #[must_use]
+    #[inline]
     pub const fn num_variables(&self) -> usize {
         // Safety: The length is guaranteed to be a power of two.
         self.0.len().ilog2() as usize
@@ -110,6 +117,7 @@ where
     ///     eq(x, point) = \prod_{i=1}^{n} (1 - p_i + 2 p_i x_i).
     /// ```
     #[must_use]
+    #[inline]
     pub fn evaluate<EF: ExtensionField<F>>(&self, point: &MultilinearPoint<EF>) -> EF {
         eval_multilinear(&self.0, point)
     }
@@ -131,7 +139,7 @@ where
     /// # Panics
     /// - If the evaluation list is not sized `2^n` for some `n`.
     #[instrument(skip_all)]
-    #[must_use]
+    #[inline]
     pub fn fold<EF>(&self, folding_randomness: &MultilinearPoint<EF>) -> EvaluationsList<EF>
     where
         EF: ExtensionField<F>,
@@ -166,6 +174,7 @@ where
 
     /// Convert from a list of evaluations to a list of multilinear coefficients.
     #[must_use]
+    #[inline]
     #[instrument(skip_all)]
     pub fn to_coefficients<B: Field>(self) -> CoefficientList<F>
     where
@@ -187,6 +196,7 @@ where
     /// ```text
     ///     p'(X_2, ..., X_n) = (p(1, X_2, ..., X_n) - p(0, X_2, ..., X_n)) \cdot r + p(0, X_2, ..., X_n)
     /// ```
+    #[inline]
     pub fn compress(&mut self, r: F) {
         // Ensure the polynomial is not a constant (i.e., has variables to fold).
         assert_ne!(self.num_variables(), 0);
@@ -223,6 +233,7 @@ where
     /// ```text
     ///     p'(X_2, ..., X_n) = (p(1, X_2, ..., X_n) - p(0, X_2, ..., X_n)) \cdot r + p(0, X_2, ..., X_n)
     /// ```
+    #[inline]
     #[instrument(skip_all)]
     pub fn compress_ext<EF: ExtensionField<F>>(&self, r: EF) -> EvaluationsList<EF> {
         assert_ne!(self.num_variables(), 0);
@@ -248,6 +259,7 @@ impl<'a, F> IntoIterator for &'a EvaluationsList<F> {
     type Item = &'a F;
     type IntoIter = std::slice::Iter<'a, F>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
     }
@@ -257,6 +269,7 @@ impl<F> IntoIterator for EvaluationsList<F> {
     type Item = F;
     type IntoIter = std::vec::IntoIter<F>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -3,9 +3,7 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
-use p3_multilinear_util::{
-    point::MultilinearPoint,
-};
+use p3_multilinear_util::point::MultilinearPoint;
 use tracing::instrument;
 
 use super::sumcheck_polynomial::SumcheckPolynomial;

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -4,7 +4,6 @@ use p3_interpolation::interpolate_subgroup;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::{
-    eq::{eval_eq, eval_eq_base},
     point::MultilinearPoint,
 };
 use tracing::instrument;
@@ -20,91 +19,6 @@ use crate::{
 };
 
 const PARALLEL_THRESHOLD: usize = 4096;
-
-/// Folds a list of evaluations from a base field `F` into an extension field `EF`.
-///
-/// This function performs an out-of-place compression of a polynomial's evaluations. It takes evaluations
-/// over a base field `F`, folds them using a random value `r` from an extension field `EF`, and returns a new
-/// list of evaluations in `EF`. This operation effectively reduces the number of variables in the
-/// represented multilinear polynomial by one.
-///
-/// ## Arguments
-/// * `evals`: A reference to an `EvaluationsList<F>` containing the evaluations of a multilinear
-///   polynomial over the boolean hypercube in the base field `F`.
-/// * `r`: A value `r` from the extension field `EF`, used as the random challenge for folding.
-///
-/// ## Returns
-/// A new `EvaluationsList<EF>` containing the compressed evaluations in the extension field.
-///
-/// The compression is achieved by applying the following formula to pairs of evaluations:
-///
-/// The compression is achieved by applying the following formula to pairs of evaluations:
-/// $p'(X_2, ..., X_n) = (p(1, X_2, ..., X_n) - p(0, X_2, ..., X_n)) \cdot r + p(0, X_2, ..., X_n)$
-#[instrument(skip_all)]
-pub fn compress_ext<F: Field, EF: ExtensionField<F>>(
-    evals: &EvaluationsList<F>,
-    r: EF,
-) -> EvaluationsList<EF> {
-    assert_ne!(evals.num_variables(), 0);
-
-    // Fold between base and extension field elements
-    let fold = |slice: &[F]| -> EF { r * (slice[1] - slice[0]) + slice[0] };
-
-    // Threshold below which sequential computation is faster
-    //
-    // This was chosen based on experiments with the `compress` function.
-    // It is possible that the threshold can be tuned further.
-    let folded = if evals.num_evals() >= PARALLEL_THRESHOLD {
-        evals.as_slice().par_chunks_exact(2).map(fold).collect()
-    } else {
-        evals.as_slice().chunks_exact(2).map(fold).collect()
-    };
-
-    EvaluationsList::new(folded)
-}
-
-/// Compresses a list of evaluations in-place using a random challenge.
-///
-/// This function performs an in-place memory optimization for the folding step
-/// in the sumcheck protocol.
-///
-/// ## Algorithm
-/// For smaller inputs, this function avoids allocating a new vector by overwriting
-/// the first half of the existing evaluation list and then truncating it.
-/// For larger inputs (determined by `PARALLEL_THRESHOLD`), it uses a parallel,
-/// out-of-place method to maximize performance, consistent with the original implementation.
-///
-/// ## Arguments
-/// * `evals`: A mutable reference to an `EvaluationsList<F>`, which will be modified in-place.
-/// * `r`: A value from the field `F`, used as the random folding challenge.
-///
-/// ## Mathematical Formula
-/// The compression is achieved by applying the following formula to pairs of evaluations:
-/// $p'(X_2, ..., X_n) = (p(1, X_2, ..., X_n) - p(0, X_2, ..., X_n)) \cdot r + p(0, X_2, ..., X_n)$
-pub fn compress<F: Field>(evals: &mut EvaluationsList<F>, r: F) {
-    // Ensure the polynomial is not a constant (i.e., has variables to fold).
-    assert_ne!(evals.num_variables(), 0);
-
-    // For large inputs, we use the original parallel, out-of-place strategy for maximum speed.
-    if evals.num_evals() >= PARALLEL_THRESHOLD {
-        // Define the folding operation for a pair of elements.
-        let fold = |slice: &[F]| -> F { r * (slice[1] - slice[0]) + slice[0] };
-        // Execute the fold in parallel and collect into a new vector.
-        let folded = evals.as_slice().par_chunks_exact(2).map(fold).collect();
-        // Replace the old evaluations with the new, folded evaluations.
-        *evals = EvaluationsList::new(folded);
-    } else {
-        // For smaller inputs, we use the sequential, in-place strategy to save memory.
-        let mid = evals.num_evals() / 2;
-        let evals_slice = evals.as_mut_slice();
-        for i in 0..mid {
-            let p0 = evals_slice[2 * i];
-            let p1 = evals_slice[2 * i + 1];
-            evals_slice[i] = r * (p1 - p0) + p0;
-        }
-        evals.truncate(mid);
-    }
-}
 
 /// Executes the initial round of the sumcheck protocol.
 ///
@@ -145,7 +59,7 @@ where
     prover_state.pow_grinding(pow_bits);
 
     // Compress polynomials and update the sum.
-    let evals = join(|| compress(weights, r), || compress_ext(evals, r)).1;
+    let evals = join(|| weights.compress(r), || evals.compress_ext(r)).1;
 
     *sum = sumcheck_poly.evaluate_on_standard_domain(&MultilinearPoint::new(vec![r]));
 
@@ -189,7 +103,7 @@ where
     prover_state.pow_grinding(pow_bits);
 
     // Compress polynomials and update the sum.
-    join(|| compress(evals, r), || compress(weights, r));
+    join(|| evals.compress(r), || weights.compress(r));
 
     *sum = sumcheck_poly.evaluate_on_standard_domain(&MultilinearPoint::new(vec![r]));
 
@@ -505,7 +419,7 @@ where
                 .iter()
                 .zip(combination_randomness.iter())
                 .for_each(|(point, &rand)| {
-                    eval_eq::<_, _, true>(point.as_slice(), self.weights.as_mut_slice(), rand);
+                    self.weights.accumulate(point, rand);
                 });
         });
 
@@ -554,7 +468,7 @@ where
                 .iter()
                 .zip(combination_randomness.iter())
                 .for_each(|(point, &rand)| {
-                    eval_eq_base::<_, _, true>(point.as_slice(), self.weights.as_mut_slice(), rand);
+                    self.weights.accumulate_base(point, rand);
                 });
         });
 

--- a/src/sumcheck/sumcheck_single_skip.rs
+++ b/src/sumcheck/sumcheck_single_skip.rs
@@ -90,7 +90,7 @@ where
 
         // Do the same for the weight polynomial w(X): shape = (2^k × 2^{n-k})
         let weights_mat = weights.clone().into_mat(width);
-        
+
         // Apply a low-degree extension (LDE) to each row of f_mat and weights_mat.
         // The LDE maps each row of length 2^k to 2^{k+1} evaluations over a multiplicative coset.
         //

--- a/src/sumcheck/sumcheck_single_skip.rs
+++ b/src/sumcheck/sumcheck_single_skip.rs
@@ -86,11 +86,11 @@ where
         //
         // This aligns with the goal of computing:
         //   h(X) = ∑_{b ∈ {0,1}^{n−k}} f(X, b) · w(X, b)
-        let f_mat = RowMajorMatrix::new(evals.as_slice().to_vec(), width);
+        let f_mat = evals.clone().into_mat(width);
 
         // Do the same for the weight polynomial w(X): shape = (2^k × 2^{n-k})
-        let weights_mat = RowMajorMatrix::new(weights.as_slice().to_vec(), width);
-
+        let weights_mat = weights.clone().into_mat(width);
+        
         // Apply a low-degree extension (LDE) to each row of f_mat and weights_mat.
         // The LDE maps each row of length 2^k to 2^{k+1} evaluations over a multiplicative coset.
         //

--- a/src/sumcheck/tests.rs
+++ b/src/sumcheck/tests.rs
@@ -4,7 +4,6 @@ use p3_field::{
     ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField, extension::BinomialExtensionField,
 };
 use p3_interpolation::interpolate_subgroup;
-use p3_matrix::dense::RowMajorMatrix;
 use p3_multilinear_util::point::MultilinearPoint;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use proptest::prelude::*;
@@ -448,7 +447,7 @@ fn run_sumcheck_test(folding_factors: &[usize], num_points: &[usize]) {
     assert_eq!(sumcheck.evals.num_evals(), 1);
 
     // Final folded value must match f(r)
-    let final_folded_value = sumcheck.evals.as_slice()[0];
+    let final_folded_value = sumcheck.evals.get_constant().unwrap();
     assert_eq!(poly.evaluate(&prover_randomness), final_folded_value);
     prover.add_extension_scalar(final_folded_value);
 
@@ -615,7 +614,7 @@ fn run_sumcheck_test_skips(folding_factors: &[usize], num_points: &[usize]) {
     assert_eq!(sumcheck.evals.num_evals(), 1);
 
     // Final constant should be f(r), where r is the accumulated challenge point
-    let constant = sumcheck.evals.as_slice()[0];
+    let constant = sumcheck.evals.get_constant().unwrap();
 
     // Final constant should be f̂(r0, r_{k+1..}) under skip semantics
     let expected = eval_with_skip::<F, EF>(&poly, K_SKIP_SUMCHECK, &prover_randomness);
@@ -741,7 +740,7 @@ where
     // Reshape f into 2^k × 2^{n-k}, interpolate along the skipped dimension at r0,
     // then evaluate the resulting EF-table on the remaining variables.
     let width = 1 << (n - k_skip);
-    let f_mat = RowMajorMatrix::new(poly.as_slice().to_vec(), width);
+    let f_mat = poly.clone().into_mat(width);
     let folded_row = interpolate_subgroup::<F, EF, _>(&f_mat, r0);
 
     EvaluationsList::new(folded_row).evaluate(&rest)

--- a/src/sumcheck/tests.rs
+++ b/src/sumcheck/tests.rs
@@ -447,7 +447,7 @@ fn run_sumcheck_test(folding_factors: &[usize], num_points: &[usize]) {
     assert_eq!(sumcheck.evals.num_evals(), 1);
 
     // Final folded value must match f(r)
-    let final_folded_value = sumcheck.evals.get_constant().unwrap();
+    let final_folded_value = sumcheck.evals.as_constant().unwrap();
     assert_eq!(poly.evaluate(&prover_randomness), final_folded_value);
     prover.add_extension_scalar(final_folded_value);
 
@@ -614,7 +614,7 @@ fn run_sumcheck_test_skips(folding_factors: &[usize], num_points: &[usize]) {
     assert_eq!(sumcheck.evals.num_evals(), 1);
 
     // Final constant should be f(r), where r is the accumulated challenge point
-    let constant = sumcheck.evals.get_constant().unwrap();
+    let constant = sumcheck.evals.as_constant().unwrap();
 
     // Final constant should be f̂(r0, r_{k+1..}) under skip semantics
     let expected = eval_with_skip::<F, EF>(&poly, K_SKIP_SUMCHECK, &prover_randomness);

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -337,7 +337,7 @@ where
                         let width = 1 << num_remaining_vars;
 
                         // Reshape the `answer` evaluations into the `2^k x 2^(n-k)` matrix format.
-                        let mat = RowMajorMatrix::new(evals.as_slice().to_vec(), width);
+                        let mat = evals.into_mat(width);
 
                         // For a skip round, `folding_randomness` is the special `(n-k)+1` challenge object.
                         let r_all = round_state.folding_randomness.clone();

--- a/src/whir/prover/round.rs
+++ b/src/whir/prover/round.rs
@@ -419,10 +419,9 @@ mod tests {
         // Check that dot product of evaluations and weights matches the final sum
         let dot_product: EF4 = sumcheck
             .evals
-            .as_slice()
             .iter()
-            .zip(sumcheck.weights.as_slice())
-            .map(|(f, w)| *f * *w)
+            .zip(&sumcheck.weights)
+            .map(|(&f, &w)| f * w)
             .sum();
         assert_eq!(dot_product, sumcheck.sum);
 
@@ -493,9 +492,8 @@ mod tests {
 
         for (f, w) in sumcheck
             .evals
-            .as_slice()
             .iter()
-            .zip(sumcheck.weights.as_slice())
+            .zip(&sumcheck.weights)
         {
             // Each evaluation should be 0
             assert_eq!(*f, EF4::ZERO);

--- a/src/whir/prover/round.rs
+++ b/src/whir/prover/round.rs
@@ -490,11 +490,7 @@ mod tests {
         let sumcheck = &state.sumcheck_prover;
         let sumcheck_randomness = state.folding_randomness.clone();
 
-        for (f, w) in sumcheck
-            .evals
-            .iter()
-            .zip(&sumcheck.weights)
-        {
+        for (f, w) in sumcheck.evals.iter().zip(&sumcheck.weights) {
             // Each evaluation should be 0
             assert_eq!(*f, EF4::ZERO);
             // Their contribution to the weighted sum should also be 0

--- a/src/whir/statement/evaluator.rs
+++ b/src/whir/statement/evaluator.rs
@@ -131,7 +131,6 @@ mod tests {
     use p3_challenger::DuplexChallenger;
     use p3_field::{PrimeCharacteristicRing, extension::BinomialExtensionField};
     use p3_interpolation::interpolate_subgroup;
-    use p3_matrix::dense::RowMajorMatrix;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
     use proptest::prelude::*;
     use rand::{Rng, SeedableRng, rngs::SmallRng};
@@ -506,7 +505,7 @@ mod tests {
             .expect("skip challenge must be present");
 
         // b) Reshape the W_0(X) evaluation table into a matrix.
-        let w0_mat = RowMajorMatrix::new(w0_combined.as_slice().to_vec(), 1 << num_remaining);
+        let w0_mat = w0_combined.into_mat(1 << num_remaining);
 
         // c) "Fold" the skipped variables by interpolating the matrix at `r_skip`.
         let folded_row = interpolate_subgroup(&w0_mat, r_skip);
@@ -641,7 +640,7 @@ mod tests {
             let r_rest = final_point.get_subpoint_over_range(0..num_remaining);
             let r_skip = *final_point.last_variable().expect("skip challenge must be present");
 
-            let w0_mat = RowMajorMatrix::new(w0_combined.as_slice().to_vec(), 1 << num_remaining);
+            let w0_mat = w0_combined.into_mat(1 << num_remaining);
             let folded_row = interpolate_subgroup(&w0_mat, r_skip);
             let w0_eval = EvaluationsList::new(folded_row).evaluate(&r_rest);
             expected_result += w0_eval;

--- a/src/whir/statement/mod.rs
+++ b/src/whir/statement/mod.rs
@@ -197,7 +197,6 @@ impl<F: Field> Statement<F> {
 mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::{PrimeCharacteristicRing, extension::BinomialExtensionField};
-    use p3_multilinear_util::eq::eval_eq;
 
     use super::*;
     use crate::whir::MultilinearPoint;
@@ -217,12 +216,11 @@ mod tests {
 
         // Expected evals for eq_z(X) where z = (1).
         // For x=0, eq=0. For x=1, eq=1.
-        let mut expected_combined_evals_vec = F::zero_vec(2);
-        eval_eq::<F, F, false>(point.0.as_slice(), &mut expected_combined_evals_vec, F::ONE);
+        let expected_combined_evals_vec = EvaluationsList::new_from_point(&point.0, F::ONE);
 
         assert_eq!(
-            combined_evals.as_slice(),
-            expected_combined_evals_vec.as_slice()
+            combined_evals,
+            expected_combined_evals_vec
         );
         assert_eq!(combined_sum, expected_eval);
     }
@@ -245,24 +243,15 @@ mod tests {
         let (combined_evals, combined_sum) = statement.combine::<F>(challenge);
 
         // Expected evals: W(X) = eq_z1(X) + challenge * eq_z2(X)
-        let mut expected_combined_evals_vec = F::zero_vec(4);
-        eval_eq::<F, F, false>(
-            point1.0.as_slice(),
-            &mut expected_combined_evals_vec,
-            F::ONE,
-        );
-        eval_eq::<F, F, true>(
-            point2.0.as_slice(),
-            &mut expected_combined_evals_vec,
-            challenge,
-        );
+        let mut expected_combined_evals_vec = EvaluationsList::new_from_point(&point1.0, F::ONE);
+        expected_combined_evals_vec.accumulate(&point2.0, challenge);
 
         // Expected sum: S = s1 + challenge * s2
         let expected_combined_sum = eval1 + challenge * eval2;
 
         assert_eq!(
-            combined_evals.as_slice(),
-            expected_combined_evals_vec.as_slice()
+            combined_evals,
+            expected_combined_evals_vec
         );
         assert_eq!(combined_sum, expected_combined_sum);
     }

--- a/src/whir/statement/mod.rs
+++ b/src/whir/statement/mod.rs
@@ -161,7 +161,7 @@ impl<F: Field> Statement<F> {
 
         // Apply the first constraint's weights directly into the buffer,
         // overwriting any uninitialized values.
-        first.point.accumulate::<Base, false>(&mut combined, gamma);
+        combined.accumulate(&first.point.0, gamma);
 
         // Initialize the combined expected sum with the first term: s_1 * γ^0.
         let mut sum = first.expected_evaluation * gamma;
@@ -172,7 +172,7 @@ impl<F: Field> Statement<F> {
             gamma *= challenge;
 
             // Add this constraint's weighted polynomial evaluations into the buffer
-            c.point.accumulate::<Base, true>(&mut combined, gamma);
+            combined.accumulate(&c.point.0, gamma);
 
             // Add this constraint's contribution to the combined expected sum:
             sum += c.expected_evaluation * gamma;

--- a/src/whir/statement/mod.rs
+++ b/src/whir/statement/mod.rs
@@ -218,10 +218,7 @@ mod tests {
         // For x=0, eq=0. For x=1, eq=1.
         let expected_combined_evals_vec = EvaluationsList::new_from_point(&point.0, F::ONE);
 
-        assert_eq!(
-            combined_evals,
-            expected_combined_evals_vec
-        );
+        assert_eq!(combined_evals, expected_combined_evals_vec);
         assert_eq!(combined_sum, expected_eval);
     }
 
@@ -249,10 +246,7 @@ mod tests {
         // Expected sum: S = s1 + challenge * s2
         let expected_combined_sum = eval1 + challenge * eval2;
 
-        assert_eq!(
-            combined_evals,
-            expected_combined_evals_vec
-        );
+        assert_eq!(combined_evals, expected_combined_evals_vec);
         assert_eq!(combined_sum, expected_combined_sum);
     }
 

--- a/src/whir/statement/mod.rs
+++ b/src/whir/statement/mod.rs
@@ -2,9 +2,7 @@ use p3_field::{ExtensionField, Field};
 use point::ConstraintPoint;
 use tracing::instrument;
 
-use crate::{
-    poly::evals::EvaluationsList, whir::statement::constraint::Constraint,
-};
+use crate::{poly::evals::EvaluationsList, whir::statement::constraint::Constraint};
 
 pub mod constraint;
 pub mod evaluator;

--- a/src/whir/statement/point.rs
+++ b/src/whir/statement/point.rs
@@ -1,8 +1,7 @@
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_multilinear_util::{eq::eval_eq, point::MultilinearPoint};
-use tracing::instrument;
+use p3_multilinear_util::{point::MultilinearPoint};
 
 use crate::poly::evals::EvaluationsList;
 
@@ -33,20 +32,6 @@ impl<F: Field> ConstraintPoint<F> {
     /// a point `y` is mapped to a multilinear point `(y, y^2, y^4, ...)`.
     pub fn univariate(point: F, size: usize) -> Self {
         Self(MultilinearPoint::expand_from_univariate(point, size))
-    }
-
-    /// Accumulates the contribution of the weight function `eq_z(X)` into `accumulator`, scaled by `factor`.
-    #[instrument(skip_all)]
-    pub fn accumulate<Base, const INITIALIZED: bool>(
-        &self,
-        accumulator: &mut EvaluationsList<F>,
-        factor: F,
-    ) where
-        Base: Field,
-        F: ExtensionField<Base>,
-    {
-        assert_eq!(accumulator.num_variables(), self.num_variables());
-        eval_eq::<Base, F, INITIALIZED>(self.0.as_slice(), accumulator.as_mut_slice(), factor);
     }
 
     /// Evaluates the weight function `eq_z(X)` at a given folding point.
@@ -81,8 +66,7 @@ impl<F: Field> ConstraintPoint<F> {
         );
 
         // Construct the evaluation table for the polynomial eq_z(X).
-        let mut evals = EvaluationsList::new(F::zero_vec(1 << n));
-        eval_eq::<_, _, false>(self.0.as_slice(), evals.as_mut_slice(), F::ONE);
+        let evals = EvaluationsList::new_from_point(&self.0, F::ONE);
 
         // Reshape the evaluation table into a matrix for folding
         //
@@ -140,19 +124,17 @@ mod tests {
 
         // Define an evaluation point
         let point = MultilinearPoint::new(vec![F::ONE]);
-        let constraint_point = ConstraintPoint::new(point.clone());
 
         // Define a multiplication factor
         let factor = F::from_u64(5);
 
         // Accumulate weighted values
-        constraint_point.accumulate::<_, true>(&mut accumulator, factor);
+        accumulator.accumulate(&point, factor);
 
         // Compute expected result manually
-        let mut expected = vec![F::ZERO, F::ZERO];
-        eval_eq::<_, _, true>(point.as_slice(), &mut expected, factor);
+        let expected = EvaluationsList::new_from_point(&point, factor);
 
-        assert_eq!(accumulator.as_slice(), &expected);
+        assert_eq!(accumulator.as_slice(), expected.as_slice());
     }
 
     #[test]

--- a/src/whir/statement/point.rs
+++ b/src/whir/statement/point.rs
@@ -1,6 +1,6 @@
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
-use p3_multilinear_util::{point::MultilinearPoint};
+use p3_multilinear_util::point::MultilinearPoint;
 
 use crate::poly::evals::EvaluationsList;
 

--- a/src/whir/statement/point.rs
+++ b/src/whir/statement/point.rs
@@ -1,6 +1,5 @@
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
-use p3_matrix::dense::RowMajorMatrix;
 use p3_multilinear_util::{point::MultilinearPoint};
 
 use crate::poly::evals::EvaluationsList;
@@ -75,7 +74,7 @@ impl<F: Field> ConstraintPoint<F> {
         // Columns correspond to the remaining variables (Xk, ..., Xn-1).
         let num_remaining_vars = n - k_skip;
         let width = 1 << num_remaining_vars;
-        let mat = RowMajorMatrix::new(evals.as_slice().to_vec(), width);
+        let mat = evals.into_mat(width);
 
         // Deconstruct the challenge object `r_all`
         //
@@ -101,6 +100,7 @@ impl<F: Field> ConstraintPoint<F> {
 mod tests {
     use p3_baby_bear::BabyBear;
     use p3_field::{PrimeCharacteristicRing, extension::BinomialExtensionField};
+    use p3_matrix::dense::RowMajorMatrix;
 
     use super::*;
 
@@ -134,7 +134,7 @@ mod tests {
         // Compute expected result manually
         let expected = EvaluationsList::new_from_point(&point, factor);
 
-        assert_eq!(accumulator.as_slice(), expected.as_slice());
+        assert_eq!(accumulator, expected);
     }
 
     #[test]

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -4,7 +4,7 @@ use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_commit::{BatchOpeningRef, ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
-use p3_matrix::{Dimensions};
+use p3_matrix::Dimensions;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::MultilinearPoint;
 use p3_symmetric::{CryptographicHasher, Hash, PseudoCompressionFunction};

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -4,7 +4,7 @@ use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_commit::{BatchOpeningRef, ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
-use p3_matrix::{Dimensions, dense::RowMajorMatrix};
+use p3_matrix::{Dimensions};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::MultilinearPoint;
 use p3_symmetric::{CryptographicHasher, Hash, PseudoCompressionFunction};
@@ -352,7 +352,7 @@ where
                     let width = 1 << num_remaining_vars;
 
                     // Reshape the flat `2^n` evaluations into a `2^k x 2^(n-k)` matrix.
-                    let mat = RowMajorMatrix::new(evals.as_slice().to_vec(), width);
+                    let mat = evals.into_mat(width);
 
                     // The `folding_randomness` for a skip round is the special `(n-k)+1` challenge object.
                     let r_all = folding_randomness.clone();


### PR DESCRIPTION
I've taken a closer look at evaluation list (due to the plonky3 PR) and I think there are a bunch of places where we can improve the abstraction.

Feel free to suggest renaming for any of the functions I've added this was more a quick overview.

In this PR:

- Make it possible to call `eval_eq` through the `EvaluationList` framework. In particular we add three functions `new_from_point, accumulate` and `accumulate_base` which let you generate an `EvaluationList` as the evaluations of the equality polynomial with respect to a given point over the boolean hypercube and update an `EvaluationList` by adding in such evaluations.
- Remove unused functions: eval_eq, truncate, parallel_clone, as_mut_slice. (Some of these were previously used but are now unused after updates.
- Add compress and compress_ext as methods.
- Add into_mat as a method.
- Add some iterator methods.

Things I think would be worth adding:
- into_mat is basically only ever used immediately before doing an FFT. We should get rid of into_mat and just have code letting you do the FFT (or something similar to this).

We may also want/need to move tests around/add tests as some of the functions e.g. compress previously existed and were tested in other folders.