### PR TITLE
Adding methods to constraint

### DIFF
--- a/src/whir/committer/reader.rs
+++ b/src/whir/committer/reader.rs
@@ -106,11 +106,10 @@ where
         self.ood_points
             .iter()
             .zip(&self.ood_answers)
-            .map(|(&point, &expected_evaluation)| Constraint {
-                point: MultilinearPoint::expand_from_univariate(point, self.num_variables),
+            .map(|(&point, &expected_evaluation)| Constraint::new(
+                MultilinearPoint::expand_from_univariate(point, self.num_variables),
                 expected_evaluation,
-                defer_evaluation: false,
-            })
+            ))
             .collect()
     }
 }
@@ -408,7 +407,7 @@ mod tests {
         assert_eq!(constraints.len(), parsed.ood_points.len());
 
         // Each constraint should have correct univariate weight, sum, and flag.
-        for (i, constraint) in constraints.iter().enumerate() {
+        for (i, constraint) in constraints.into_iter().enumerate() {
             let point = parsed.ood_points[i];
             let expected_eval = parsed.ood_answers[i];
 
@@ -421,16 +420,8 @@ mod tests {
             ]);
 
             assert_eq!(
-                constraint.point, expected_point,
-                "Constraint {i} has incorrect weight"
-            );
-            assert_eq!(
-                constraint.expected_evaluation, expected_eval,
-                "Constraint {i} has incorrect sum"
-            );
-            assert!(
-                !constraint.defer_evaluation,
-                "Constraint {i} should not defer evaluation"
+                constraint, Constraint::new(expected_point, expected_eval),
+                "Constraint {i} is incorrect"
             );
         }
     }

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -138,7 +138,7 @@ where
         prover_state: &mut ProverState<F, EF, Challenger>,
         statement: Statement<EF>,
         witness: Witness<EF, F, DenseMatrix<F>, DIGEST_ELEMS>,
-    ) -> Result<(MultilinearPoint<EF>, Vec<EF>), FiatShamirError>
+    ) -> Result<MultilinearPoint<EF>, FiatShamirError>
     where
         H: CryptographicHasher<F, [F; DIGEST_ELEMS]>
             + CryptographicHasher<F::Packing, [F::Packing; DIGEST_ELEMS]>
@@ -172,18 +172,7 @@ where
         round_state.randomness_vec.reverse();
         let constraint_eval = MultilinearPoint::new(round_state.randomness_vec);
 
-        // Hints for deferred constraints
-        let deferred = round_state
-            .statement
-            .constraints
-            .iter()
-            .filter(|constraint| constraint.defer_evaluation)
-            .map(|constraint| constraint.point.eq_poly(&constraint_eval))
-            .collect::<Vec<_>>();
-
-        prover_state.hint_extension_scalars(&deferred);
-
-        Ok((constraint_eval, deferred))
+        Ok(constraint_eval)
     }
 
     #[instrument(skip_all, fields(round_number = round_index, log_size = self.num_variables - self.folding_factor.total_number(round_index)))]

--- a/src/whir/statement/mod.rs
+++ b/src/whir/statement/mod.rs
@@ -70,11 +70,7 @@ impl<F: Field> Statement<F> {
     /// Panics if the number of variables in the `point` does not match the statement.
     pub fn add_constraint(&mut self, point: MultilinearPoint<F>, expected_evaluation: F) {
         assert_eq!(point.num_variables(), self.num_variables());
-        self.constraints.push(Constraint {
-            point,
-            expected_evaluation,
-            defer_evaluation: false,
-        });
+        self.constraints.push(Constraint::new(point, expected_evaluation));
     }
 
     /// Inserts an evaluation constraint `p(z) = s` at the front of the system.
@@ -85,11 +81,7 @@ impl<F: Field> Statement<F> {
         assert_eq!(point.num_variables(), self.num_variables());
         self.constraints.insert(
             0,
-            Constraint {
-                point,
-                expected_evaluation,
-                defer_evaluation: false,
-            },
+            Constraint::new(point, expected_evaluation),
         );
     }
 
@@ -109,11 +101,7 @@ impl<F: Field> Statement<F> {
             assert_eq!(point.num_variables(), n);
 
             // Convert the pair into a full `Constraint` with `defer_evaluation = false`.
-            new_constraints.push(Constraint {
-                point,
-                expected_evaluation,
-                defer_evaluation: false,
-            });
+            new_constraints.push(Constraint::new(point, expected_evaluation));
         }
 
         // Insert all new constraints at the beginning of the existing list.
@@ -148,11 +136,11 @@ impl<F: Field> Statement<F> {
         let (first, rest) = self.constraints.split_first().unwrap();
 
         // Initialize the combined evaluations with the first constraint's polynomial.
-        let mut combined = EvaluationsList::new_from_point(&first.point, F::ONE);
+        let mut combined = EvaluationsList::new_from_point(first.point(), F::ONE);
 
         // Initialize the combined expected sum with the first term: s_1 * γ^0 = s_1.
         let mut gamma = F::ONE;
-        let mut sum = first.expected_evaluation;
+        let mut sum = first.expected_eval();
 
         // Process the remaining constraints.
         for c in rest {
@@ -160,24 +148,16 @@ impl<F: Field> Statement<F> {
             gamma *= challenge;
 
             // Add this constraint's weighted polynomial evaluations into the buffer
-            combined.accumulate(&c.point, gamma);
+            combined.accumulate(c.point(), gamma);
 
             // Add this constraint's contribution to the combined expected sum:
-            sum += c.expected_evaluation * gamma;
+            sum += c.expected_eval() * gamma;
         }
 
         // Return:
         // - The combined polynomial W(X) in evaluation form.
         // - The combined expected sum S.
         (combined, sum)
-    }
-
-    #[must_use]
-    pub fn num_deref_constraints(&self) -> usize {
-        self.constraints
-            .iter()
-            .filter(|constraint| constraint.defer_evaluation)
-            .count()
     }
 }
 

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -17,11 +17,10 @@ use super::{
 };
 use crate::{
     constant::K_SKIP_SUMCHECK,
-    fiat_shamir::{errors::FiatShamirError, verifier::VerifierState},
+    fiat_shamir::verifier::VerifierState,
     poly::{evals::EvaluationsList, multilinear::MultilinearPoint},
     whir::{
-        Statement, parameters::WhirConfig, statement::evaluator::ConstraintPolyEvaluator,
-        verifier::sumcheck::verify_sumcheck_rounds,
+        parameters::WhirConfig, statement::{constraint::linear_combine_constraints, evaluator::ConstraintPolyEvaluator}, verifier::sumcheck::verify_sumcheck_rounds, Statement
     },
 };
 
@@ -58,7 +57,7 @@ where
         verifier_state: &mut VerifierState<F, EF, Challenger>,
         parsed_commitment: &ParsedCommitment<EF, Hash<F, F, DIGEST_ELEMS>>,
         statement: &Statement<EF>,
-    ) -> Result<(MultilinearPoint<EF>, Vec<EF>), VerifierError>
+    ) -> Result<MultilinearPoint<EF>, VerifierError>
     where
         H: CryptographicHasher<F, [F; DIGEST_ELEMS]> + Sync,
         C: PseudoCompressionFunction<[F; DIGEST_ELEMS], 2> + Sync,
@@ -80,7 +79,7 @@ where
                 .chain(statement.constraints.iter().cloned())
                 .collect();
             let combination_randomness =
-                self.combine_constraints(verifier_state, &mut claimed_sum, &constraints)?;
+                self.combine_constraints(verifier_state, &mut claimed_sum, &constraints);
             round_constraints.push((combination_randomness, constraints));
 
             // Initial sumcheck
@@ -136,7 +135,7 @@ where
                 .collect();
 
             let combination_randomness =
-                self.combine_constraints(verifier_state, &mut claimed_sum, &constraints)?;
+                self.combine_constraints(verifier_state, &mut claimed_sum, &constraints);
             round_constraints.push((combination_randomness.clone(), constraints));
 
             let folding_randomness = verify_sumcheck_rounds(
@@ -195,19 +194,13 @@ where
                 .collect(),
         );
 
-        // Compute evaluation of weights in folding randomness
-        // Some weight computations can be deferred and will be returned for the caller
-        // to verify.
-        let deferred =
-            verifier_state.next_extension_scalars_vec(statement.num_deref_constraints())?;
-
         let evaluator = ConstraintPolyEvaluator::new(
             self.num_variables,
             self.folding_factor,
             self.univariate_skip,
         );
         let evaluation_of_weights =
-            evaluator.eval_constraints_poly(&round_constraints, &deferred, &folding_randomness);
+            evaluator.eval_constraints_poly(&round_constraints, &folding_randomness);
 
         // Check the final sumcheck evaluation
         let final_value = final_evaluations.evaluate(&final_sumcheck_randomness);
@@ -219,7 +212,7 @@ where
             });
         }
 
-        Ok((folding_randomness, deferred))
+        Ok(folding_randomness)
     }
 
     /// Combine multiple constraints into a single claim using random linear combination.
@@ -243,18 +236,13 @@ where
         verifier_state: &mut VerifierState<F, EF, Challenger>,
         claimed_sum: &mut EF,
         constraints: &[Constraint<EF>],
-    ) -> Result<Vec<EF>, FiatShamirError> {
+    ) -> Vec<EF> {
         let combination_randomness_gen: EF = verifier_state.sample();
-        let combination_randomness = combination_randomness_gen
-            .powers()
-            .collect_n(constraints.len());
-        *claimed_sum += constraints
-            .iter()
-            .zip(&combination_randomness)
-            .map(|(c, &rand)| rand * c.expected_evaluation)
-            .sum::<EF>();
-
-        Ok(combination_randomness)
+        linear_combine_constraints(
+            claimed_sum,
+            constraints,
+            combination_randomness_gen,
+        )
     }
 
     /// Verify STIR in-domain queries and produce associated constraints.
@@ -386,14 +374,13 @@ where
             .iter()
             .map(|&index| params.folded_domain_gen.exp_u64(index as u64))
             .zip(&folds)
-            .map(|(point, &expected_evaluation)| Constraint {
-                point: MultilinearPoint::expand_from_univariate(
+            .map(|(point, &expected_evaluation)| Constraint::new(
+                MultilinearPoint::expand_from_univariate(
                     EF::from(point),
                     params.num_variables,
                 ),
                 expected_evaluation,
-                defer_evaluation: false,
-            })
+            ))
             .collect();
 
         Ok(stir_constraints)


### PR DESCRIPTION
The goal of this PR is to add clarity around the purpose of the constraint struct.

Working through this I do wonder if there is a better way to encapsulate this idea (essentially get rid of `Constraint` and focus on `Statement` as the core type) I might try that in a separate PR. Currently, outside of `verify`, every other method on `Constraint` is either a constructor or a destructor which suggests that this might not be the right encapsulation.

Regardless, the main changes in this PR are:
- Remove `defer_evaluation` and everything referring to it.
- Add a `new` method and methods to retrieve the point and the claimed evaluation.
- Remove `pub` from the point and claimed evaluation. (These should not be changed after the constraint is initialized so should probably not be pub)
- Move `combine_constraints` which has been copied in `2` places into the constraint file.
