### PR TITLE
Make points pub(crate) and remove get_points.

### DIFF
--- a/src/whir/constraints/evaluator.rs
+++ b/src/whir/constraints/evaluator.rs
@@ -1,7 +1,9 @@
 use p3_field::{ExtensionField, Field, TwoAdicField};
 
 use crate::{
-    constant::K_SKIP_SUMCHECK, parameters::FoldingFactor, poly::multilinear::MultilinearPoint,
+    constant::K_SKIP_SUMCHECK,
+    parameters::FoldingFactor,
+    poly::multilinear::MultilinearPoint,
     whir::{constraints::statement::Statement, parameters::WhirConfig},
 };
 
@@ -76,7 +78,8 @@ impl ConstraintPolyEvaluator {
                 && self.univariate_skip
                 && self.folding_factor.at_round(0) >= K_SKIP_SUMCHECK;
 
-            let round_sum: EF = round_statement.points
+            let round_sum: EF = round_statement
+                .points
                 .iter()
                 .zip(alpha_pows)
                 .map(|(point, &alpha_i)| {
@@ -210,12 +213,7 @@ mod tests {
             .iter()
             .cloned()
             .zip(&alphas)
-            .map(|(statement, &alpha)| {
-                (
-                    alpha.powers().collect_n(statement.len()),
-                    statement,
-                )
-            })
+            .map(|(statement, &alpha)| (alpha.powers().collect_n(statement.len()), statement))
             .collect();
 
         // Generate the final, full 20-dimensional challenge point `r`.

--- a/src/whir/constraints/evaluator.rs
+++ b/src/whir/constraints/evaluator.rs
@@ -2,7 +2,7 @@ use p3_field::{ExtensionField, Field, TwoAdicField};
 
 use crate::{
     constant::K_SKIP_SUMCHECK, parameters::FoldingFactor, poly::multilinear::MultilinearPoint,
-    whir::parameters::WhirConfig,
+    whir::{constraints::statement::Statement, parameters::WhirConfig},
 };
 
 /// Lightweight evaluator for the combined constraint polynomial W(r).
@@ -45,7 +45,7 @@ impl ConstraintPolyEvaluator {
     #[must_use]
     pub fn eval_constraints_poly<EF>(
         &self,
-        constraints: &[(Vec<EF>, Vec<MultilinearPoint<EF>>)],
+        constraints: &[(Vec<EF>, Statement<EF>)],
         point: &MultilinearPoint<EF>,
     ) -> EF
     where
@@ -56,7 +56,7 @@ impl ConstraintPolyEvaluator {
 
         let mut acc = EF::ZERO;
 
-        for (round_idx, (alpha_pows, round_constraint_points)) in constraints.iter().enumerate() {
+        for (round_idx, (alpha_pows, round_statement)) in constraints.iter().enumerate() {
             // Construct the point slice appropriate for this round.
             //
             // For round 0 we use the full `point`:
@@ -76,7 +76,7 @@ impl ConstraintPolyEvaluator {
                 && self.univariate_skip
                 && self.folding_factor.at_round(0) >= K_SKIP_SUMCHECK;
 
-            let round_sum: EF = round_constraint_points
+            let round_sum: EF = round_statement.points
                 .iter()
                 .zip(alpha_pows)
                 .map(|(point, &alpha_i)| {
@@ -213,7 +213,7 @@ mod tests {
             .map(|(statement, &alpha)| {
                 (
                     alpha.powers().collect_n(statement.len()),
-                    statement.get_points(),
+                    statement,
                 )
             })
             .collect();
@@ -355,7 +355,7 @@ mod tests {
                 .iter()
                 .cloned()
                 .zip(&alphas)
-                .map(|(s, &a)| (a.powers().collect_n(s.len()), s.get_points()))
+                .map(|(s, &a)| (a.powers().collect_n(s.len()), s))
                 .collect();
 
             // Generate the final, full n-dimensional challenge point `r`.
@@ -467,7 +467,7 @@ mod tests {
             .iter()
             .cloned()
             .zip(&alphas)
-            .map(|(s, &a)| (a.powers().collect_n(s.len()), s.get_points()))
+            .map(|(s, &a)| (a.powers().collect_n(s.len()), s))
             .collect();
 
         // For a skip protocol, the verifier's final challenge object has a special
@@ -606,7 +606,7 @@ mod tests {
                 .iter()
                 .cloned()
                 .zip(&alphas)
-                .map(|(s, &a)| (a.powers().collect_n(s.len()), s.get_points()))
+                .map(|(s, &a)| (a.powers().collect_n(s.len()), s))
                 .collect();
 
             // For a skip protocol, the verifier's final challenge object has a special

--- a/src/whir/constraints/statement.rs
+++ b/src/whir/constraints/statement.rs
@@ -39,7 +39,7 @@ pub struct Statement<F> {
     /// Number of variables in the multilinear polynomial space.
     num_variables: usize,
     /// List of evaluation points.
-    points: Vec<MultilinearPoint<F>>,
+    pub(crate) points: Vec<MultilinearPoint<F>>,
     /// List of target evaluations.
     evaluations: Vec<F>,
 }
@@ -108,12 +108,6 @@ impl<F: Field> Statement<F> {
         assert_eq!(self.num_variables, other.num_variables);
         self.points.extend_from_slice(&other.points);
         self.evaluations.extend_from_slice(&other.evaluations);
-    }
-
-    /// Returns the vector of evaluation points.
-    #[must_use]
-    pub fn get_points(self) -> Vec<MultilinearPoint<F>> {
-        self.points
     }
 
     /// Adds an evaluation constraint `p(z) = s` to the system.

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -79,7 +79,7 @@ where
             let gamma = verifier_state.sample();
             let combination_randomness = new_statement.combine_evals(&mut claimed_sum, gamma);
 
-            round_constraints.push((combination_randomness, new_statement.get_points()));
+            round_constraints.push((combination_randomness, new_statement));
 
             // Initial sumcheck
             let folding_randomness = verify_sumcheck_rounds(
@@ -93,7 +93,7 @@ where
         } else {
             assert!(prev_commitment.ood_points.is_empty());
             assert!(statement.is_empty());
-            round_constraints.push((vec![], vec![]));
+            round_constraints.push((vec![], Statement::initialize(statement.num_variables())));
 
             let folding_randomness = MultilinearPoint::new(
                 (0..self.folding_factor.at_round(0))
@@ -133,7 +133,7 @@ where
             let gamma = verifier_state.sample();
             let combination_randomness = new_statement.combine_evals(&mut claimed_sum, gamma);
 
-            round_constraints.push((combination_randomness.clone(), new_statement.get_points()));
+            round_constraints.push((combination_randomness.clone(), new_statement));
 
             let folding_randomness = verify_sumcheck_rounds(
                 verifier_state,


### PR DESCRIPTION
I think this is cleaner. lmk if you disagree.

Basically we only actually need to get the points in the crate so we can make `points` `pub(crate)` which is pretty safe (particularly compared to `pub`) and not need the `get_points` function which felt a little off.