### PR TITLE
Faster compression of eqs

### DIFF
--- a/src/whir/constraints/statement.rs
+++ b/src/whir/constraints/statement.rs
@@ -1,8 +1,5 @@
 use p3_field::{ExtensionField, Field};
-use rayon::{
-    iter::{IndexedParallelIterator, ParallelIterator},
-    slice::{ParallelSlice, ParallelSliceMut},
-};
+use p3_maybe_rayon::prelude::*;
 use tracing::instrument;
 
 use crate::poly::{evals::EvaluationsList, multilinear::MultilinearPoint};


### PR DESCRIPTION
This PR speeds up `Statement::combine` function that compresses multiple eqs with a randomness. Compression itself has more than 2x speed and `prove` function reduces from ~900ms to ~600ms when I run `RUSTFLAGS='-C target-cpu=native' cargo run --release `