### PR TITLE
fix typo in variable name

### DIFF
--- a/src/fiat_shamir/domain_separator.rs
+++ b/src/fiat_shamir/domain_separator.rs
@@ -137,9 +137,9 @@ where
     {
         // TODO: Add params
         self.observe(DIGEST_ELEMS, Observe::MerkleDigest);
-        if params.committment_ood_samples > 0 {
+        if params.commitment_ood_samples > 0 {
             assert!(params.initial_statement);
-            self.add_ood(params.committment_ood_samples);
+            self.add_ood(params.commitment_ood_samples);
         }
     }
 

--- a/src/whir/committer/reader.rs
+++ b/src/whir/committer/reader.rs
@@ -154,7 +154,7 @@ where
         ParsedCommitment::<_, Hash<F, F, DIGEST_ELEMS>>::parse(
             verifier_state,
             self.num_variables,
-            self.committment_ood_samples,
+            self.commitment_ood_samples,
         )
     }
 }
@@ -231,7 +231,7 @@ mod tests {
         let mut config = WhirConfig::new(num_variables, whir_params);
 
         // Set the number of OOD samples for commitment testing.
-        config.committment_ood_samples = ood_samples;
+        config.commitment_ood_samples = ood_samples;
 
         // Return the config and a thread-local random number generator.
         (config, rand::rng())

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -93,7 +93,7 @@ where
         // Handle OOD (Out-Of-Domain) samples
         let (ood_points, ood_answers) = sample_ood_points(
             prover_state,
-            self.committment_ood_samples,
+            self.commitment_ood_samples,
             self.num_variables,
             |point| info_span!("ood evaluation").in_scope(|| polynomial.evaluate(point)),
         );
@@ -206,7 +206,7 @@ mod tests {
         // Validate the number of generated OOD points.
         assert_eq!(
             witness.ood_points.len(),
-            params.committment_ood_samples,
+            params.commitment_ood_samples,
             "OOD points count should match expected samples"
         );
 
@@ -310,7 +310,7 @@ mod tests {
             WhirConfig::<F, F, MyHash, MyCompress, MyChallenger>::new(num_variables, whir_params);
 
         // Explicitly set OOD samples to 0
-        params.committment_ood_samples = 0;
+        params.commitment_ood_samples = 0;
 
         let mut rng = rand::rng();
         let polynomial = EvaluationsList::<BabyBear>::new(vec![rng.random(); 32]);
@@ -331,7 +331,7 @@ mod tests {
 
         assert!(
             witness.ood_points.is_empty(),
-            "There should be no OOD points when committment_ood_samples is 0"
+            "There should be no OOD points when commitment_ood_samples is 0"
         );
     }
 }

--- a/src/whir/parameters.rs
+++ b/src/whir/parameters.rs
@@ -29,7 +29,7 @@ where
     pub security_level: usize,
     pub max_pow_bits: usize,
 
-    pub committment_ood_samples: usize,
+    pub commitment_ood_samples: usize,
     // The WHIR protocol can prove either:
     // 1. The commitment is a valid low degree polynomial. In that case, the initial statement is
     //    set to false.
@@ -107,7 +107,7 @@ where
             .folding_factor
             .compute_number_of_rounds(num_variables);
 
-        let committment_ood_samples = if whir_parameters.initial_statement {
+        let commitment_ood_samples = if whir_parameters.initial_statement {
             whir_parameters.soundness_type.determine_ood_samples(
                 whir_parameters.security_level,
                 num_variables,
@@ -224,7 +224,7 @@ where
             security_level: whir_parameters.security_level,
             max_pow_bits: whir_parameters.pow_bits,
             initial_statement: whir_parameters.initial_statement,
-            committment_ood_samples,
+            commitment_ood_samples,
             num_variables: initial_num_variables,
             soundness_type: whir_parameters.soundness_type,
             starting_log_inv_rate: whir_parameters.starting_log_inv_rate,


### PR DESCRIPTION
Noticed this while reading the code and writing a variant using the uniform sampling feature of: https://github.com/Plonky3/Plonky3/pull/1050 (for which I'll open a PR shortly).

I had some minor changes of the `src/whir/statements/mod.rs` file that seems to have been deleted in here too. 