### PR TITLE
use uniform sampling of bits

### DIFF
--- a/benches/sumcheck.rs
+++ b/benches/sumcheck.rs
@@ -1,8 +1,8 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-use p3_challenger::{DuplexChallenger, FieldChallenger, GrindingChallenger};
+use p3_challenger::{DuplexChallenger, FieldChallenger, UniformGrindingChallenger};
 use p3_field::extension::BinomialExtensionField;
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use whir_p3::{
     fiat_shamir::{domain_separator::DomainSeparator, prover::ProverState},
     poly::{evals::EvaluationsList, multilinear::MultilinearPoint},
@@ -38,7 +38,7 @@ fn generate_statement<C>(
     num_constraints: usize,
 ) -> Statement<EF>
 where
-    C: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    C: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     let mut statement = Statement::initialize(num_vars);
     for _ in 0..num_constraints {

--- a/src/fiat_shamir/domain_separator.rs
+++ b/src/fiat_shamir/domain_separator.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, GrindingChallenger, UniformGrindingChallenger};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 
 use crate::{
@@ -104,7 +104,7 @@ where
         challenger: Challenger,
     ) -> ProverState<F, EF, Challenger>
     where
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
     {
         ProverState::new(self, challenger)
     }
@@ -117,7 +117,7 @@ where
         challenger: Challenger,
     ) -> VerifierState<F, EF, Challenger>
     where
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
     {
         VerifierState::new(self, proof_data, challenger)
     }
@@ -133,7 +133,7 @@ where
         &mut self,
         params: &WhirConfig<EF, F, HC, C, Challenger>,
     ) where
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
     {
         // TODO: Add params
         self.observe(DIGEST_ELEMS, Observe::MerkleDigest);
@@ -147,7 +147,7 @@ where
         &mut self,
         params: &WhirConfig<EF, F, HC, C, Challenger>,
     ) where
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
         EF: TwoAdicField,
         F: TwoAdicField,
     {

--- a/src/sumcheck/sumcheck_single.rs
+++ b/src/sumcheck/sumcheck_single.rs
@@ -1,4 +1,4 @@
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, GrindingChallenger, UniformGrindingChallenger};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
 use p3_maybe_rayon::prelude::*;
@@ -43,7 +43,9 @@ fn initial_round<Challenger, F: Field, EF: ExtensionField<F>>(
     pow_bits: usize,
 ) -> (EF, EvaluationsList<EF>)
 where
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F>
+        + GrindingChallenger<Witness = F>
+        + UniformGrindingChallenger<Witness = F>,
 {
     // Compute the quadratic sumcheck polynomial for the current variable.
     let sumcheck_poly = compute_sumcheck_polynomial(evals, weights, *sum);
@@ -89,7 +91,7 @@ fn round<Challenger, F: Field, EF: ExtensionField<F>>(
     pow_bits: usize,
 ) -> EF
 where
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     // Compute the quadratic sumcheck polynomial for the current variable.
     let sumcheck_poly = compute_sumcheck_polynomial(evals, weights, *sum);
@@ -270,7 +272,7 @@ where
     where
         F: TwoAdicField,
         EF: TwoAdicField,
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
     {
         assert_ne!(folding_factor, 0);
         let mut res = Vec::with_capacity(folding_factor);
@@ -319,7 +321,7 @@ where
     where
         F: TwoAdicField,
         EF: TwoAdicField,
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
     {
         assert_ne!(folding_factor, 0);
         let mut res = Vec::with_capacity(folding_factor);
@@ -522,7 +524,7 @@ where
     where
         F: TwoAdicField,
         EF: TwoAdicField,
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
     {
         // Standard round-by-round folding
         // Proceed with one-variable-per-round folding for remaining variables.

--- a/src/sumcheck/tests.rs
+++ b/src/sumcheck/tests.rs
@@ -1,12 +1,12 @@
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-use p3_challenger::{DuplexChallenger, FieldChallenger, GrindingChallenger};
+use p3_challenger::{DuplexChallenger, FieldChallenger, UniformGrindingChallenger};
 use p3_field::{
-    ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField, extension::BinomialExtensionField,
+    extension::BinomialExtensionField, ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField,
 };
 use p3_interpolation::interpolate_subgroup;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use proptest::prelude::*;
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 use super::sumcheck_single::SumcheckSingle;
 use crate::{
@@ -85,7 +85,7 @@ fn make_initial_statement<Challenger>(
     poly: &EvaluationsList<F>,
 ) -> Statement<EF>
 where
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     // Initialize the statement to hold the evaluation constraints.
     let mut statement = Statement::initialize(num_vars);
@@ -136,7 +136,7 @@ fn make_inter_statement<Challenger>(
     sumcheck: &mut SumcheckSingle<F, EF>,
 ) -> (Statement<EF>, EF)
 where
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     // Determine how many variables are left in the current sumcheck polynomial.
     let num_vars = sumcheck.num_variables();
@@ -203,7 +203,7 @@ fn read_statement<Challenger>(
     num_points: usize,
 ) -> Statement<EF>
 where
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     // Create a new statement that will hold all reconstructed constraints.
     let mut statement = Statement::initialize(num_vars);

--- a/src/whir/committer/reader.rs
+++ b/src/whir/committer/reader.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, ops::Deref};
 
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_symmetric::Hash;
 
@@ -66,7 +66,7 @@ where
     where
         F: TwoAdicField,
         EF: ExtensionField<F> + TwoAdicField,
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
     {
         // Read the Merkle root hash committed by the prover.
         let root = verifier_state
@@ -134,7 +134,7 @@ impl<'a, EF, F, H, C, Challenger> CommitmentReader<'a, EF, F, H, C, Challenger>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     /// Create a new commitment reader from a WHIR configuration.
     ///

--- a/src/whir/committer/writer.rs
+++ b/src/whir/committer/writer.rs
@@ -1,9 +1,9 @@
 use std::{ops::Deref, sync::Arc};
 
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, TwoAdicField};
-use p3_matrix::{Matrix, dense::RowMajorMatrix};
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{CryptographicHasher, PseudoCompressionFunction};
 use serde::{Deserialize, Serialize};
@@ -37,7 +37,7 @@ impl<'a, EF, F, H, C, Challenger> CommitmentWriter<'a, EF, F, H, C, Challenger>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     /// Create a new writer that borrows the WHIR protocol configuration.
     pub const fn new(params: &'a WhirConfig<EF, F, H, C, Challenger>) -> Self {

--- a/src/whir/parameters.rs
+++ b/src/whir/parameters.rs
@@ -1,9 +1,9 @@
 use std::{f64::consts::LOG2_10, marker::PhantomData};
 
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 
-use crate::parameters::{FoldingFactor, ProtocolParameters, errors::SecurityAssumption};
+use crate::parameters::{errors::SecurityAssumption, FoldingFactor, ProtocolParameters};
 
 #[derive(Debug, Clone)]
 pub struct RoundConfig<F> {
@@ -65,7 +65,7 @@ impl<EF, F, Hash, C, Challenger> WhirConfig<EF, F, Hash, C, Challenger>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     #[allow(clippy::too_many_lines)]
     pub fn new(num_variables: usize, whir_parameters: ProtocolParameters<Hash, C>) -> Self {

--- a/src/whir/prover/mod.rs
+++ b/src/whir/prover/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
@@ -54,7 +54,7 @@ impl<EF, F, H, C, Challenger> Prover<'_, EF, F, H, C, Challenger>
 where
     F: TwoAdicField + Ord,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     /// Validates that the total number of variables expected by the prover configuration
     /// matches the number implied by the folding schedule and the final rounds.

--- a/src/whir/prover/round_state/state.rs
+++ b/src/whir/prover/round_state/state.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::DenseMatrix;
 use p3_merkle_tree::MerkleTree;
@@ -153,7 +153,7 @@ where
         witness: Witness<EF, F, DenseMatrix<F>, DIGEST_ELEMS>,
     ) -> Result<Self, FiatShamirError>
     where
-        Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+        Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
         MyChallenger: Clone,
         C: Clone,
     {

--- a/src/whir/utils.rs
+++ b/src/whir/utils.rs
@@ -1,10 +1,10 @@
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_field::{ExtensionField, Field};
 use p3_util::log2_strict_usize;
 use tracing::instrument;
 
 use crate::{
-    fiat_shamir::{ChallengeSampler, errors::FiatShamirError, prover::ProverState},
+    fiat_shamir::{errors::FiatShamirError, prover::ProverState, ChallengeSampler},
     poly::multilinear::MultilinearPoint,
 };
 
@@ -185,7 +185,7 @@ pub fn sample_ood_points<F: Field, EF: ExtensionField<F>, E, Challenger>(
 ) -> (Vec<EF>, Vec<EF>)
 where
     E: Fn(&MultilinearPoint<EF>) -> EF,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     let mut ood_points = EF::zero_vec(num_samples);
     let mut ood_answers = Vec::with_capacity(num_samples);

--- a/src/whir/verifier/mod.rs
+++ b/src/whir/verifier/mod.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, ops::Deref};
 
 use errors::VerifierError;
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_commit::{BatchOpeningRef, ExtensionMmcs, Mmcs};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
@@ -44,7 +44,7 @@ impl<'a, EF, F, H, C, Challenger> Verifier<'a, EF, F, H, C, Challenger>
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     pub const fn new(params: &'a WhirConfig<EF, F, H, C, Challenger>) -> Self {
         Self(params)

--- a/src/whir/verifier/sumcheck.rs
+++ b/src/whir/verifier/sumcheck.rs
@@ -1,4 +1,4 @@
-use p3_challenger::{FieldChallenger, GrindingChallenger};
+use p3_challenger::{FieldChallenger, UniformGrindingChallenger};
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_interpolation::interpolate_subgroup;
 use p3_matrix::dense::RowMajorMatrix;
@@ -47,7 +47,7 @@ pub(crate) fn verify_sumcheck_rounds<EF, F, Challenger>(
 where
     F: TwoAdicField,
     EF: ExtensionField<F> + TwoAdicField,
-    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    Challenger: FieldChallenger<F> + UniformGrindingChallenger<Witness = F>,
 {
     // Calculate how many `(poly, rand)` pairs to expect based on skip mode
     //
@@ -144,9 +144,9 @@ where
 mod tests {
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_challenger::DuplexChallenger;
-    use p3_field::{PrimeCharacteristicRing, extension::BinomialExtensionField};
+    use p3_field::{extension::BinomialExtensionField, PrimeCharacteristicRing};
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-    use rand::{SeedableRng, rngs::SmallRng};
+    use rand::{rngs::SmallRng, SeedableRng};
 
     use super::*;
     use crate::{
@@ -154,7 +154,7 @@ mod tests {
             domain_separator::{DomainSeparator, SumcheckParams},
             pattern::{Observe, Sample},
         },
-        parameters::{FoldingFactor, ProtocolParameters, errors::SecurityAssumption},
+        parameters::{errors::SecurityAssumption, FoldingFactor, ProtocolParameters},
         poly::coeffs::CoefficientList,
         sumcheck::sumcheck_single::SumcheckSingle,
         whir::{constraints::statement::Statement, parameters::WhirConfig},


### PR DESCRIPTION
This implements using the uniform sampling of this Plonky3 PR: https://github.com/Plonky3/Plonky3/pull/1050

It gives an idea of the amount of code one needs to change. Essentially it's all about changing a lot of `GrindingChallenger` traits to `UniformGrindingChallenger`. Aside from that it is just 3 lines (I think) to change `sample_bits` to `sample_uniform_bits_may_panic` and `grind` to `grind_uniform_may_panic` (where we use the overloads that may panic instead of doing rejection sampling).

Feel free to look at this or wait until we actually decide if the above Plonky3 PR is even going to be merged at all. Things seem to work locally here at least.