### PR TITLE
Carlo/proof svo

### DIFF
--- a/src/whir/proof.rs
+++ b/src/whir/proof.rs
@@ -173,7 +173,6 @@ pub struct SumcheckData<EF, F> {
     pub pow_witnesses: Option<Vec<F>>,
 }
 
-
 impl<F: Default, EF: Default, const DIGEST_ELEMS: usize> WhirProof<F, EF, DIGEST_ELEMS> {
     /// Create a new WhirProof from protocol parameters and configuration
     ///


### PR DESCRIPTION
Updated the WhirProof structure to also include svo optimization. The sum check data has been changed into an enum to reflect the 2 possible behaviors: 3 EF in standard sumcheck,  2 in svo. Svo is also been included in the InitialPhase, in which the first 3 rounds are going to be stored. The remaing rounds are going to be stored into WhirRoundProof, and they will keep on being on the 2 EF variation. 