### PR TITLE
Guard prox_gaps_error against invalid num_functions

### DIFF
--- a/src/parameters/errors.rs
+++ b/src/parameters/errors.rs
@@ -250,6 +250,20 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "num_functions must be >= 2")]
+    fn prox_gaps_error_panics_when_num_functions_is_one() {
+        let assumption = SecurityAssumption::UniqueDecoding;
+        let _ = assumption.prox_gaps_error(1, 1, 64, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "num_functions must be >= 2")]
+    fn prox_gaps_error_panics_when_num_functions_is_zero() {
+        let assumption = SecurityAssumption::UniqueDecoding;
+        let _ = assumption.prox_gaps_error(1, 1, 64, 0);
+    }
+
+    #[test]
     fn test_ud_errors() {
         let assumption = SecurityAssumption::UniqueDecoding;
 


### PR DESCRIPTION
Previously `prox_gaps_error` accepted any `num_functions` and would compute `log2(num_functions - 1)`, yielding NaN/∞ if 1 or 0 slipped in. 

This PR adds a guard asserting `num_functions >= 2`, matching the intended multi-function domain and the current callers (all pass 2), so misuse fails fast instead of corrupting soundness estimates.