### PR TITLE
Optimize sumcheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,5 +118,9 @@ name = "sumcheck_svo"
 harness = false
 
 [[bench]]
+name = "sumcheck_compare"
+harness = false
+
+[[bench]]
 name = "stir_queries"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,5 +114,9 @@ name = "sumcheck"
 harness = false
 
 [[bench]]
+name = "sumcheck_svo"
+harness = false
+
+[[bench]]
 name = "stir_queries"
 harness = false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
 # whir-p3
 
 A version of https://github.com/WizardOfMenlo/whir/ which uses the Plonky3 library.
+
+## Sumcheck benchmark comparison
+
+The repository includes a unified benchmark for comparing the classical sumcheck prover
+against the SVO implementation ported from the Jolt approach:
+
+```bash
+cargo bench --bench sumcheck_compare -- --noplot
+```
+
+This comparison uses the same setup for both implementations:
+
+- `BabyBear` field
+- the same random multilinear polynomial
+- the same 3 sampled evaluation constraints
+- the same challenger initialization
+- the same first-round folding parameter `l0 = 4`
+
+Criterion midpoint timings from the unified benchmark:
+
+| num_vars | Classic | Svo | Speedup |
+| --- | ---: | ---: | ---: |
+| 16 | 1.3647 ms | 1.1459 ms | 1.19x |
+| 18 | 3.1021 ms | 1.9203 ms | 1.62x |
+| 20 | 8.0524 ms | 3.6310 ms | 2.22x |
+| 22 | 23.991 ms | 8.3096 ms | 2.89x |
+| 24 | 86.095 ms | 21.958 ms | 3.92x |
+
+The main takeaway is that the SVO/Jolt-style path becomes increasingly faster than the
+classical prover as the number of variables grows.

--- a/benches/sumcheck_compare.rs
+++ b/benches/sumcheck_compare.rs
@@ -1,0 +1,154 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::{DuplexChallenger, FieldChallenger};
+use p3_field::extension::BinomialExtensionField;
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use rand::{RngExt, SeedableRng, rngs::SmallRng};
+use whir_p3::{
+    fiat_shamir::domain_separator::DomainSeparator,
+    parameters::{FoldingFactor, ProtocolParameters, errors::SecurityAssumption},
+    poly::{evals::EvaluationsList, multilinear::MultilinearPoint},
+    sumcheck::sumcheck_prover::Sumcheck,
+    whir::{
+        constraints::statement::initial::InitialStatement,
+        parameters::SumcheckStrategy,
+        proof::{SumcheckData, WhirProof},
+    },
+};
+
+type F = BabyBear;
+type EF = BinomialExtensionField<BabyBear, 4>;
+type Perm = Poseidon2BabyBear<16>;
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+type MyChallenger = DuplexChallenger<F, Perm, 16, 8>;
+
+const NUM_VARS_TO_BENCH: [usize; 5] = [16, 18, 20, 22, 24];
+const NUM_CONSTRAINTS: usize = 3;
+const FIRST_ROUND_FOLDING: usize = 4;
+
+fn create_test_protocol_params(
+    first_round_folding: usize,
+) -> ProtocolParameters<MyHash, MyCompress> {
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Perm::new_from_rng_128(&mut rng);
+
+    ProtocolParameters {
+        security_level: 32,
+        pow_bits: 0,
+        rs_domain_initial_reduction_factor: 1,
+        folding_factor: FoldingFactor::Constant(first_round_folding),
+        merkle_hash: MyHash::new(perm.clone()),
+        merkle_compress: MyCompress::new(perm),
+        soundness_type: SecurityAssumption::UniqueDecoding,
+        starting_log_inv_rate: 1,
+    }
+}
+
+fn setup_challenger() -> MyChallenger {
+    let mut rng = SmallRng::seed_from_u64(0);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    MyChallenger::new(perm)
+}
+
+fn generate_poly(num_vars: usize) -> EvaluationsList<F> {
+    let mut rng = SmallRng::seed_from_u64(1);
+    let evals = (0..1 << num_vars).map(|_| rng.random()).collect();
+    EvaluationsList::new(evals)
+}
+
+fn sample_constraint_points(num_vars: usize, num_constraints: usize) -> Vec<MultilinearPoint<EF>> {
+    let domsep: DomainSeparator<EF, F> = DomainSeparator::new(vec![]);
+    let mut challenger = setup_challenger();
+    domsep.observe_domain_separator(&mut challenger);
+
+    (0..num_constraints)
+        .map(|_| {
+            MultilinearPoint::expand_from_univariate(challenger.sample_algebra_element(), num_vars)
+        })
+        .collect()
+}
+
+fn build_statement(
+    poly: &EvaluationsList<F>,
+    points: &[MultilinearPoint<EF>],
+    strategy: SumcheckStrategy,
+) -> InitialStatement<F, EF> {
+    let mut statement = InitialStatement::new(poly.clone(), FIRST_ROUND_FOLDING, strategy);
+    for point in points {
+        let _ = statement.evaluate(point);
+    }
+    statement
+}
+
+fn run_sumcheck(
+    params: &ProtocolParameters<MyHash, MyCompress>,
+    base_challenger: &MyChallenger,
+    statement: &InitialStatement<F, EF>,
+    num_vars: usize,
+) {
+    let mut challenger = base_challenger.clone();
+    let mut proof = WhirProof::<F, EF, F, 8>::from_protocol_parameters(params, num_vars);
+
+    let (mut sumcheck_prover, _) = Sumcheck::from_base_evals(
+        &mut proof.initial_sumcheck,
+        &mut challenger,
+        FIRST_ROUND_FOLDING,
+        0,
+        statement,
+    );
+
+    let remaining_rounds = num_vars - FIRST_ROUND_FOLDING;
+    if remaining_rounds > 0 {
+        let mut sumcheck_data = SumcheckData::default();
+        sumcheck_prover.compute_sumcheck_polynomials(
+            &mut sumcheck_data,
+            &mut challenger,
+            remaining_rounds,
+            0,
+            None,
+        );
+        proof.set_final_sumcheck_data(sumcheck_data);
+    }
+}
+
+fn bench_sumcheck_compare(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SumcheckCompare");
+    group.sample_size(10);
+
+    for num_vars in NUM_VARS_TO_BENCH {
+        let params = create_test_protocol_params(FIRST_ROUND_FOLDING);
+        let poly = generate_poly(num_vars);
+        let points = sample_constraint_points(num_vars, NUM_CONSTRAINTS);
+
+        let classic_statement = build_statement(&poly, &points, SumcheckStrategy::Classic);
+        let svo_statement = build_statement(&poly, &points, SumcheckStrategy::Svo);
+
+        assert_eq!(classic_statement.normalize(), svo_statement.normalize());
+
+        let domsep: DomainSeparator<EF, F> = DomainSeparator::new(vec![]);
+        let mut challenger = setup_challenger();
+        domsep.observe_domain_separator(&mut challenger);
+
+        group.bench_with_input(
+            BenchmarkId::new("Classic", num_vars),
+            &classic_statement,
+            |b, statement| {
+                b.iter(|| run_sumcheck(&params, &challenger, statement, num_vars));
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("Svo", num_vars),
+            &svo_statement,
+            |b, statement| {
+                b.iter(|| run_sumcheck(&params, &challenger, statement, num_vars));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_sumcheck_compare);
+criterion_main!(benches);

--- a/benches/sumcheck_svo.rs
+++ b/benches/sumcheck_svo.rs
@@ -56,8 +56,8 @@ fn generate_poly(num_vars: usize) -> EvaluationsList<F> {
     EvaluationsList::new(evals)
 }
 
-/// Main benchmark function to test the classic sumcheck prover.
-fn bench_sumcheck_prover_classic(c: &mut Criterion) {
+/// Main benchmark function to test the SVO sumcheck prover.
+fn bench_sumcheck_prover_svo(c: &mut Criterion) {
     let mut group = c.benchmark_group("SumcheckProver");
     // Use a smaller sample size for long-running benchmarks
     group.sample_size(10);
@@ -66,9 +66,6 @@ fn bench_sumcheck_prover_classic(c: &mut Criterion) {
     for num_vars in &[16, 18, 20, 22, 24] {
         // Generate a large polynomial to use for this set of benchmarks.
         let poly = generate_poly(*num_vars);
-
-        // Benchmark for the classic, round-by-round sumcheck
-        let classic_folding_schedule = [*num_vars / 2, num_vars - (*num_vars / 2)];
 
         // Create parameters with a dummy folding factor (we'll use manual schedule)
         let params = create_test_protocol_params(FoldingFactor::Constant(2));
@@ -80,12 +77,15 @@ fn bench_sumcheck_prover_classic(c: &mut Criterion) {
         let mut challenger = setup_challenger();
         domsep.observe_domain_separator(&mut challenger);
 
-        // Create constraint using challenger directly
-        let mut initial_statement = InitialStatement::new(
-            poly.clone(),
+        // SVO first phase must match the strategy initialization parameter.
+        let svo_folding_schedule = [
             params.folding_factor.at_round(0),
-            SumcheckStrategy::Classic,
-        );
+            num_vars - params.folding_factor.at_round(0),
+        ];
+
+        // Create constraint using challenger directly
+        let mut initial_statement =
+            InitialStatement::new(poly.clone(), svo_folding_schedule[0], SumcheckStrategy::Svo);
         for _ in 0..3 {
             let _ = initial_statement.evaluate(&MultilinearPoint::expand_from_univariate(
                 challenger.sample_algebra_element(),
@@ -94,11 +94,12 @@ fn bench_sumcheck_prover_classic(c: &mut Criterion) {
         }
 
         group.bench_with_input(
-            BenchmarkId::new("Classic", *num_vars),
+            BenchmarkId::new("Svo", *num_vars),
             &(initial_statement, challenger.clone()),
             |b, (initial_statement, challenger)| {
                 b.iter(|| {
                     let mut challenger = challenger.clone();
+
                     // Initialize proof
                     let mut proof =
                         WhirProof::<F, EF, F, 8>::from_protocol_parameters(&params, *num_vars);
@@ -107,18 +108,18 @@ fn bench_sumcheck_prover_classic(c: &mut Criterion) {
                     let (mut sumcheck_prover, _) = Sumcheck::from_base_evals(
                         &mut proof.initial_sumcheck,
                         &mut challenger,
-                        classic_folding_schedule[0],
+                        svo_folding_schedule[0],
                         0,
                         initial_statement,
                     );
 
                     // Second round - fold remaining variables
-                    if classic_folding_schedule.len() > 1 && classic_folding_schedule[1] > 0 {
+                    if svo_folding_schedule.len() > 1 && svo_folding_schedule[1] > 0 {
                         let mut sumcheck_data: SumcheckData<F, EF> = SumcheckData::default();
                         sumcheck_prover.compute_sumcheck_polynomials(
                             &mut sumcheck_data,
                             &mut challenger,
-                            classic_folding_schedule[1],
+                            svo_folding_schedule[1],
                             0,
                             None,
                         );
@@ -132,5 +133,5 @@ fn bench_sumcheck_prover_classic(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_sumcheck_prover_classic);
+criterion_group!(benches, bench_sumcheck_prover_svo);
 criterion_main!(benches);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.94"

--- a/src/poly/evals.rs
+++ b/src/poly/evals.rs
@@ -445,6 +445,61 @@ where
             });
         EvaluationsList(out)
     }
+
+    /// Computes sumcheck coefficients directly from base-field evaluations and packed weights.
+    ///
+    /// This avoids materializing a packed copy of `self` just to compute `(h(0), h(2))`.
+    #[instrument(skip_all, level = "debug")]
+    pub fn sumcheck_coefficients_packed<EF>(
+        &self,
+        weights: &EvaluationsList<EF::ExtensionPacking>,
+    ) -> (EF::ExtensionPacking, EF::ExtensionPacking)
+    where
+        EF: ExtensionField<F>,
+        EF::ExtensionPacking: Copy + Send + Sync + Algebra<F::Packing>,
+    {
+        let evals = F::Packing::pack_slice(self.as_slice());
+        let weights = weights.as_slice();
+
+        // Validate inputs: need at least 2 elements (1 variable).
+        assert!(log2_strict_usize(evals.len()) >= 1);
+        assert_eq!(evals.len(), weights.len());
+
+        // Split arrays into lo (X=0) and hi (X=1) halves.
+        let mid = evals.len() / 2;
+        let (evals_lo, evals_hi) = evals.split_at(mid);
+        let (weights_lo, weights_hi) = weights.split_at(mid);
+
+        if evals.len() >= PARALLEL_THRESHOLD {
+            evals_lo
+                .par_iter()
+                .zip(evals_hi.par_iter())
+                .zip(weights_lo.par_iter().zip(weights_hi.par_iter()))
+                .map(|((&e_lo, &e_hi), (&w_lo, &w_hi))| {
+                    let c0_term = w_lo * e_lo;
+                    let c2_term = (w_hi.double() - w_lo) * (e_hi.double() - e_lo);
+                    (c0_term, c2_term)
+                })
+                .par_fold_reduce(
+                    || (Default::default(), Default::default()),
+                    |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
+                    |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
+                )
+        } else {
+            evals_lo
+                .iter()
+                .zip(evals_hi.iter())
+                .zip(weights_lo.iter().zip(weights_hi.iter()))
+                .fold(
+                    (Default::default(), Default::default()),
+                    |(a0, a2), ((&e_lo, &e_hi), (&w_lo, &w_hi))| {
+                        let c0_term = w_lo * e_lo;
+                        let c2_term = (w_hi.double() - w_lo) * (e_hi.double() - e_lo);
+                        (a0 + c0_term, a2 + c2_term)
+                    },
+                )
+        }
+    }
 }
 
 impl<A: Copy + Send + Sync + PrimeCharacteristicRing> EvaluationsList<A> {
@@ -506,23 +561,38 @@ impl<A: Copy + Send + Sync + PrimeCharacteristicRing> EvaluationsList<A> {
         let (evals_lo, evals_hi) = evals.split_at(mid);
         let (weights_lo, weights_hi) = weights.split_at(mid);
 
-        // Parallel computation of c_0 and c_2.
-        evals_lo
-            .par_iter()
-            .zip(evals_hi.par_iter())
-            .zip(weights_lo.par_iter().zip(weights_hi.par_iter()))
-            .map(|((&e_lo, &e_hi), (&w_lo, &w_hi))| {
-                // c_0 term: product at X=0.
-                let c0_term = w_lo * e_lo;
-                // c_2 term: cross-product of differences.
-                let c2_term = (w_hi.double() - w_lo) * (e_hi.double() - e_lo);
-                (c0_term, c2_term)
-            })
-            .par_fold_reduce(
-                || (B::ZERO, B::ZERO),
-                |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
-                |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
-            )
+        if evals.len() >= PARALLEL_THRESHOLD {
+            // Parallel computation of c_0 and c_2.
+            evals_lo
+                .par_iter()
+                .zip(evals_hi.par_iter())
+                .zip(weights_lo.par_iter().zip(weights_hi.par_iter()))
+                .map(|((&e_lo, &e_hi), (&w_lo, &w_hi))| {
+                    // c_0 term: product at X=0.
+                    let c0_term = w_lo * e_lo;
+                    // c_2 term: cross-product of differences.
+                    let c2_term = (w_hi.double() - w_lo) * (e_hi.double() - e_lo);
+                    (c0_term, c2_term)
+                })
+                .par_fold_reduce(
+                    || (B::ZERO, B::ZERO),
+                    |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
+                    |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
+                )
+        } else {
+            evals_lo
+                .iter()
+                .zip(evals_hi.iter())
+                .zip(weights_lo.iter().zip(weights_hi.iter()))
+                .fold(
+                    (B::ZERO, B::ZERO),
+                    |(a0, a2), ((&e_lo, &e_hi), (&w_lo, &w_hi))| {
+                        let c0_term = w_lo * e_lo;
+                        let c2_term = (w_hi.double() - w_lo) * (e_hi.double() - e_lo);
+                        (a0 + c0_term, a2 + c2_term)
+                    },
+                )
+        }
     }
 }
 
@@ -2420,6 +2490,35 @@ mod tests {
         // h(2) = (2*w1 - w0) * (2*e1 - e0)
         let expected_h2 = (w1.double() - w0) * (e1.double() - e0);
         assert_eq!(h2, expected_h2);
+    }
+
+    #[test]
+    fn test_sumcheck_coefficients_packed_matches_materialized_packed() {
+        let mut rng = SmallRng::seed_from_u64(1234);
+        let num_vars = log2_strict_usize(<F as Field>::Packing::WIDTH) + 2;
+        let num_evals = 1 << num_vars;
+        let pack_width = <F as Field>::Packing::WIDTH;
+
+        let evals: Vec<F> = (0..num_evals).map(|_| rng.random()).collect();
+        let weights: Vec<EF4> = (0..num_evals).map(|_| rng.random()).collect();
+
+        let evals_list = EvaluationsList::new(evals.clone());
+        let weights_packed = EvaluationsList::new(
+            weights
+                .chunks(pack_width)
+                .map(<EF4 as ExtensionField<F>>::ExtensionPacking::from_ext_slice)
+                .collect(),
+        );
+
+        // New path: avoid materializing packed evals.
+        let (c0_new, c2_new) = evals_list.sumcheck_coefficients_packed::<EF4>(&weights_packed);
+
+        // Previous path: materialize packed evals first, then call generic kernel.
+        let evals_packed = EvaluationsList::new(<F as Field>::Packing::pack_slice(&evals).to_vec());
+        let (c0_old, c2_old) = evals_packed.sumcheck_coefficients(&weights_packed);
+
+        assert_eq!(c0_new, c0_old);
+        assert_eq!(c2_new, c2_old);
     }
 
     #[test]

--- a/src/sumcheck/sumcheck_prover.rs
+++ b/src/sumcheck/sumcheck_prover.rs
@@ -132,9 +132,8 @@ where
         // This directly writes the equality portion of W(X) to `weights`.
         statement.combine_hypercube_packed::<F, false>(&mut weights, &mut sum, alpha);
 
-        let poly_packed = Poly::new(F::Packing::pack_slice(poly.as_slice()).to_vec());
         // Compute the constant (c₀) and quadratic (c₂) coefficients of h(X).
-        let (c0, c2) = poly_packed.sumcheck_coefficients(&weights);
+        let (c0, c2) = poly.sumcheck_coefficients_packed::<EF>(&weights);
         // Reduce packed results to scalar via horizontal sum.
         let c0 = EF::ExtensionPacking::to_ext_iter([c0]).sum();
         let c2 = EF::ExtensionPacking::to_ext_iter([c2]).sum();

--- a/src/whir/verifier/sumcheck.rs
+++ b/src/whir/verifier/sumcheck.rs
@@ -39,6 +39,14 @@ where
     EF: ExtensionField<F> + TwoAdicField,
     Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
 {
+    if pow_bits > 0 && sumcheck.pow_witnesses.len() != sumcheck.polynomial_evaluations.len() {
+        return Err(VerifierError::SumcheckFailed {
+            round: 0,
+            expected: format!("{} PoW witnesses", sumcheck.polynomial_evaluations.len()),
+            actual: format!("{} PoW witnesses", sumcheck.pow_witnesses.len()),
+        });
+    }
+
     let mut randomness = Vec::with_capacity(sumcheck.polynomial_evaluations.len());
 
     for (i, &[c0, c2]) in sumcheck.polynomial_evaluations.iter().enumerate() {
@@ -321,5 +329,32 @@ mod tests {
             randomness, expected_randomness,
             "Mismatch in full MultilinearPoint folding randomness"
         );
+    }
+
+    #[test]
+    fn test_verify_sumcheck_rounds_pow_witness_len_mismatch() {
+        let mut rng = SmallRng::seed_from_u64(11);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let mut challenger = MyChallenger::new(perm);
+
+        // One round polynomial but zero PoW witnesses.
+        let mut sumcheck: SumcheckData<F, EF> = SumcheckData::default();
+        sumcheck
+            .polynomial_evaluations
+            .push([EF::from_u64(3), EF::from_u64(7)]);
+
+        let mut claimed_sum = EF::from_u64(10);
+        let err = verify_sumcheck_rounds(&sumcheck, &mut challenger, &mut claimed_sum, 1)
+            .expect_err("expected witness-length mismatch");
+
+        match err {
+            VerifierError::SumcheckFailed {
+                expected, actual, ..
+            } => {
+                assert_eq!(expected, "1 PoW witnesses");
+                assert_eq!(actual, "0 PoW witnesses");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
This PR includes a unified benchmark for comparing the classical sumcheck prover
against the SVO implementation ported from the Jolt approach. At a high level it does three things:

- It splits the old mixed benchmark into separate classic and SVO benchmarks. `benches/sumcheck.rs` now measures only the classical prover path, `benches/sumcheck_svo.rs` adds a standalone SVO benchmark, and `Cargo.toml` registers the new bench target.

- It optimizes packed sumcheck coefficient computation. `src/poly/evals.rs` adds `sumcheck_coefficients_packed`, which computes (c0, c2) directly from base-field evaluations plus packed weights instead of first materializing a packed copy of the polynomial. The same file also adds a sequential path for small inputs. `src/sumcheck/sumcheck_prover.rs` switches the packed classic prover to use that new helper.

- It hardens verifier behavior around PoW witnesses. `src/whir/verifier/sumcheck.rs` now checks that the number of PoW witnesses matches the number of recorded sumcheck rounds before indexing into the witness list, and adds a regression test for the mismatch case.

Sumcheck benchmark comparison

```bash
cargo bench --bench sumcheck_compare -- --noplot
```

This comparison uses the same setup for both implementations:

- `BabyBear` field
- the same random multilinear polynomial
- the same 3 sampled evaluation constraints
- the same challenger initialization
- the same first-round folding parameter `l0 = 4`

Criterion midpoint timings from the unified benchmark:

| num_vars | Classic | Svo | Speedup |
| --- | ---: | ---: | ---: |
| 16 | 1.3647 ms | 1.1459 ms | 1.19x |
| 18 | 3.1021 ms | 1.9203 ms | 1.62x |
| 20 | 8.0524 ms | 3.6310 ms | 2.22x |
| 22 | 23.991 ms | 8.3096 ms | 2.89x |
| 24 | 86.095 ms | 21.958 ms | 3.92x |

The main takeaway is that the SVO/Jolt-style path becomes increasingly faster than the
classical prover as the number of variables grows.
